### PR TITLE
게시글 리스트 조회 페이지 [#front-18]

### DIFF
--- a/app/(site)/boards/BoardListClient.tsx
+++ b/app/(site)/boards/BoardListClient.tsx
@@ -1,0 +1,371 @@
+// "use client";
+
+// import Pagination from "@/app/components/Pagination";
+// import api from "@/app/lib/api";
+// import { useRouter } from "next/navigation";
+// import { useEffect, useState } from "react";
+
+// interface BoardPage {
+//   page: number;
+//   size: number;
+//   totalPages: number;
+//   totalCount: number;
+//   boardList: Board[];
+// }
+
+// //응답
+// interface Board {
+//   id: number;
+//   nickname: string;
+//   title: string;
+//   content: string;
+//   image_url: string;
+//   likesCount: number;
+//   viewsCount: number;
+//   commentsCount: number;
+//   createdAt: string;
+//   updatedAt: string;
+//   category: string;
+//   petType: string;
+// }
+
+// export default function BoardListPage() {
+//   const [boards, setBoards] = useState<Board[]>([]);
+//   const [loading, setLoading] = useState(true);
+//   const [category, setCategory] = useState<string>("TOTAL");
+//   const [option, setOption] = useState<string>("TOTAL");
+//   const [keyword, setKeyword] = useState<string>("");
+//   const [search, setSearch] = useState<boolean>(false);
+//   const [sort, setSort] = useState<string>("CURRENT");
+
+//   const router = useRouter();
+
+//   const categories = [
+//     { label: "전체", value: "TOTAL" },
+//     { label: "커뮤니티", value: "FREE" },
+//     { label: "Q & A", value: "QNA" },
+//   ];
+
+//   const petTypes = [
+//     { label: "강아지", value: "DOG" },
+//     { label: "고양이", value: "CAT" },
+//     { label: "기타", value: "ETC" },
+//   ];
+
+//   const selectOptions = [
+//     { label: "전체", value: "TOTAL" },
+//     { label: "작성자", value: "USERNAME" },
+//     { label: "제목", value: "TITLE" },
+//     { label: "내용", value: "CONTENT" },
+//   ];
+
+//   const selectSort = [
+//     { label: "최신 순", value: "CURRENT" },
+//     { label: "좋아요 순", value: "LIKES" },
+//     { label: "댓글 순", value: "COMMENTS" },
+//     { label: "조회 순", value: "VIEWS" },
+//   ];
+
+//   useEffect(() => {
+//     getBoard();
+//   }, [category, search, sort]);
+
+//   async function getBoard() {
+//     // 요청
+//     const payload = {
+//       category: category,
+//       searchType: option,
+//       sortType: sort,
+//       keyword: keyword,
+//       page: 0,
+//       size: 10,
+//     };
+
+//     try {
+//       const res = await api.get("/boards", { params: payload });
+//       setBoards(res.data.boardList); // 배열만 저장
+//       console.log(res.data);
+//     } catch (err) {
+//       console.error(err);
+//     } finally {
+//       setLoading(false); // 무조건 로딩 종료
+//     }
+//   }
+//   if (loading) return <h1>Loading…</h1>;
+
+//   function selectCategory(value: string) {
+//     resetFilter();
+//     setCategory(value);
+//   }
+
+//   function selectOption(e: React.ChangeEvent<HTMLSelectElement>) {
+//     setOption(e.target.value);
+//   }
+
+//   function InputKeyword(e: React.ChangeEvent<HTMLInputElement>) {
+//     setKeyword(e.target.value);
+//   }
+
+//   function searchKeyword(bool: boolean) {
+//     setSearch(bool);
+//     getBoard();
+//   }
+
+//   function checkSort(value: string) {
+//     setSort(value);
+//   }
+//   function goCreate() {
+//     router.push("/boards/new");
+//   }
+
+//   function resetFilter() {
+//     setOption("TOTAL");
+//     setKeyword("");
+//     setBoards([]);
+//     getBoard();
+//   }
+
+//   function changeResponse<T extends { label: string; value: string }>(
+//     list: T[],
+//     value: string
+//   ) {
+//     return list.find((item) => item.value == value)?.label;
+//   }
+
+//   return (
+//     <>
+//       {/* 카테고리 바 */}
+//       <div className="flex gap-5 p-5">
+//         {categories.map((category) => (
+//           <button
+//             key={category.value}
+//             onClick={() => selectCategory(category.value)}
+//           >
+//             {category.label}
+//           </button>
+//         ))}
+//       </div>
+//       {/* 검색 필터링 */}
+//       <div className="flex items-center gap-2">
+//         <select onChange={selectOption} value={option}>
+//           {selectOptions.map((op) => (
+//             <option key={op.value} value={op.value}>
+//               {op.label}
+//             </option>
+//           ))}
+//         </select>
+//         {/* 검색바 */}
+//         <input
+//           value={keyword}
+//           onChange={InputKeyword}
+//           placeholder="찾으시는 글이 있으신가요?"
+//         ></input>
+//         <button onClick={() => searchKeyword(true)}>검색</button>
+//         <button onClick={resetFilter}>초기화</button>
+//       </div>
+//       {/* 정렬 */}
+//       <div className="flex items-center gap-2">
+//         {selectSort.map((option) => (
+//           <label key={option.value}>
+//             <input
+//               type="radio"
+//               key={option.value}
+//               value={option.value}
+//               checked={sort == option.value}
+//               onChange={() => checkSort(option.value)}
+//             />
+//             {option.label}
+//           </label>
+//         ))}
+//         <button onClick={goCreate}>새글쓰기</button>
+//       </div>
+
+//       <ul>
+//         {boards.map((board) => (
+//           <li key={board.id}>
+//             {changeResponse(categories, board.category)}
+//             {changeResponse(petTypes, board.petType)}
+//             {board.title}
+//             {board.content}
+//             {board.nickname}
+//             {board.viewsCount}|{board.likesCount}|{board.commentsCount}
+//             {board.createdAt.split("T")[0]}{" "}
+//           </li>
+//         ))}
+//       </ul>
+//     </>
+//   );
+// }
+
+"use client";
+import Pagination from "@/app/components/Pagination";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useState } from "react";
+
+//응답
+interface Board {
+  id: number;
+  nickname: string;
+  title: string;
+  content: string;
+  image_url: string;
+  likesCount: number;
+  viewsCount: number;
+  commentsCount: number;
+  createdAt: string;
+  updatedAt: string;
+  category: string;
+  petType: string;
+}
+
+interface Props {
+  boards: Board[];
+  currentPage: number;
+  totalPages: number;
+  filters: {
+    category: string;
+    searchType: string;
+    keyword: string;
+    sortType: string;
+  };
+}
+
+export default function BoardListPage({
+  boards,
+  currentPage,
+  totalPages,
+  filters,
+}: Props) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [keyword, setKeyword] = useState<string>(filters.keyword);
+  //const [loading, setLoading] = useState(false);
+
+  const updateQuery = (key: string, value: string) => {
+    //setLoading(true);
+    const params = new URLSearchParams(searchParams.toString());
+    params.set(key, value);
+    if (key !== "page") params.set("page", "1");
+    router.push(`?${params.toString()}`);
+  };
+
+  //if (loading) return <div>로딩 중입니다...</div>;
+
+  const categories = [
+    { label: "전체", value: "TOTAL" },
+    { label: "커뮤니티", value: "FREE" },
+    { label: "Q & A", value: "QNA" },
+  ];
+
+  const petTypes = [
+    { label: "강아지", value: "DOG" },
+    { label: "고양이", value: "CAT" },
+    { label: "기타", value: "ETC" },
+  ];
+
+  const selectOptions = [
+    { label: "전체", value: "TOTAL" },
+    { label: "작성자", value: "USERNAME" },
+    { label: "제목", value: "TITLE" },
+    { label: "내용", value: "CONTENT" },
+  ];
+
+  const selectSort = [
+    { label: "최신 순", value: "CURRENT" },
+    { label: "좋아요 순", value: "LIKES" },
+    { label: "댓글 순", value: "COMMENTS" },
+    { label: "조회 순", value: "VIEWS" },
+  ];
+  function goCreate() {
+    router.push("/boards/new");
+  }
+
+  function resetFilter() {
+    const params = new URLSearchParams();
+    params.set("category", "TOTAL");
+    params.set("searchType", "TOTAL");
+    params.set("keyword", "");
+    params.set("sortType", "CURRENT");
+    params.set("page", "1");
+    router.push(`?${params.toString()}`);
+  }
+
+  function changeResponse<T extends { label: string; value: string }>(
+    list: T[],
+    value: string
+  ) {
+    return list.find((item) => item.value == value)?.label;
+  }
+
+  return (
+    <>
+      {/* 카테고리 바 */}
+      <div className="flex gap-5 p-5">
+        {categories.map((category) => (
+          <button
+            key={category.value}
+            onClick={() => updateQuery("category", category.value)}
+          >
+            {category.label}
+          </button>
+        ))}
+      </div>
+      {/* 검색 필터링 */}
+      <div className="flex items-center gap-2">
+        <select
+          value={filters.searchType}
+          onChange={(e) => updateQuery("searchType", e.target.value)}
+        >
+          {selectOptions.map((op) => (
+            <option key={op.value} value={op.value}>
+              {op.label}
+            </option>
+          ))}
+        </select>
+        {/* 검색바 */}
+        <input
+          value={keyword}
+          onChange={(e) => setKeyword(e.target.value)}
+          placeholder="찾으시는 글이 있으신가요?"
+        ></input>
+        <button onClick={() => updateQuery("keyword", keyword)}>검색</button>
+        <button onClick={resetFilter}>초기화</button>
+      </div>
+      {/* 정렬 */}
+      <div className="flex items-center gap-2">
+        {selectSort.map((option) => (
+          <label key={option.value}>
+            <input
+              type="radio"
+              key={option.value}
+              value={option.value}
+              checked={filters.sortType == option.value}
+              onChange={() => updateQuery("sortType", option.value)}
+            />
+            {option.label}
+          </label>
+        ))}
+        <button onClick={goCreate}>새글쓰기</button>
+      </div>
+
+      <ul>
+        {boards.map((board) => (
+          <li key={board.id}>
+            {changeResponse(categories, board.category)}
+            {changeResponse(petTypes, board.petType)}
+            {board.title}
+            {board.content}
+            {board.nickname}
+            {board.viewsCount}|{board.likesCount}|{board.commentsCount}
+            {board.createdAt.split("T")[0]}{" "}
+          </li>
+        ))}
+      </ul>
+      <Pagination
+        currentPage={currentPage}
+        totalPages={totalPages}
+        blockSize={5}
+      />
+    </>
+  );
+}

--- a/app/(site)/boards/BoardListClient.tsx
+++ b/app/(site)/boards/BoardListClient.tsx
@@ -197,12 +197,196 @@
 //   );
 // }
 
+// CSR
+// "use client";
+// import Pagination from "@/app/components/Pagination";
+// import { useRouter, useSearchParams } from "next/navigation";
+// import { useState } from "react";
+
+// //응답
+// interface Board {
+//   id: number;
+//   nickname: string;
+//   title: string;
+//   content: string;
+//   image_url: string;
+//   likesCount: number;
+//   viewsCount: number;
+//   commentsCount: number;
+//   createdAt: string;
+//   updatedAt: string;
+//   category: string;
+//   petType: string;
+// }
+
+// interface Props {
+//   boards: Board[];
+//   currentPage: number;
+//   totalPages: number;
+//   filters: {
+//     category: string;
+//     searchType: string;
+//     keyword: string;
+//     sortType: string;
+//   };
+// }
+
+// export default function BoardListPage({
+//   boards,
+//   currentPage,
+//   totalPages,
+//   filters,
+// }: Props) {
+//   const router = useRouter();
+//   const searchParams = useSearchParams();
+//   const [keyword, setKeyword] = useState<string>(filters.keyword);
+//   const [searchType, setSearchType] = useState<string>(filters.searchType);
+//   //const [loading, setLoading] = useState(false);
+
+//   const updateQuery = (key: string, value: string) => {
+//     //setLoading(true);
+//     const params = new URLSearchParams(searchParams.toString());
+//     params.set(key, value);
+//     if (key !== "page") params.set("page", "1");
+//     router.push(`?${params.toString()}`);
+//   };
+
+//   //if (loading) return <div>로딩 중입니다...</div>;
+
+//   const categories = [
+//     { label: "전체", value: "TOTAL" },
+//     { label: "커뮤니티", value: "FREE" },
+//     { label: "Q & A", value: "QNA" },
+//   ];
+
+//   const petTypes = [
+//     { label: "강아지", value: "DOG" },
+//     { label: "고양이", value: "CAT" },
+//     { label: "기타", value: "ETC" },
+//   ];
+
+//   const selectOptions = [
+//     { label: "전체", value: "TOTAL" },
+//     { label: "작성자", value: "USERNAME" },
+//     { label: "제목", value: "TITLE" },
+//     { label: "내용", value: "CONTENT" },
+//   ];
+
+//   const selectSort = [
+//     { label: "최신 순", value: "CURRENT" },
+//     { label: "좋아요 순", value: "LIKES" },
+//     { label: "댓글 순", value: "COMMENTS" },
+//     { label: "조회 순", value: "VIEWS" },
+//   ];
+//   function goCreate() {
+//     router.push("/boards/new");
+//   }
+
+//   function handleSearch() {
+//     const params = new URLSearchParams(searchParams.toString());
+//     params.set("searchType", searchType);
+//     params.set("keyword", keyword);
+//     params.set("page", "1");
+//     router.push(`?${params.toString()}`);
+//   }
+
+//   function resetFilter() {
+//     const params = new URLSearchParams();
+//     params.set("category", "TOTAL");
+//     params.set("searchType", "TOTAL");
+//     params.set("keyword", "");
+//     params.set("sortType", "CURRENT");
+//     params.set("page", "1");
+//     router.push(`?${params.toString()}`);
+//     setKeyword("");
+//     setSearchType("TOTAL");
+//   }
+
+//   function changeResponse<T extends { label: string; value: string }>(
+//     list: T[],
+//     value: string
+//   ) {
+//     return list.find((item) => item.value == value)?.label;
+//   }
+
+//   return (
+//     <>
+//       {/* 카테고리 바 */}
+//       <div className="flex gap-5 p-5">
+//         {categories.map((category) => (
+//           <button
+//             key={category.value}
+//             onClick={() => updateQuery("category", category.value)}
+//           >
+//             {category.label}
+//           </button>
+//         ))}
+//       </div>
+//       {/* 검색 필터링 */}
+//       <div className="flex items-center gap-2">
+//         <select
+//           value={searchType}
+//           onChange={(e) => setSearchType(e.target.value)}
+//         >
+//           {selectOptions.map((op) => (
+//             <option key={op.value} value={op.value}>
+//               {op.label}
+//             </option>
+//           ))}
+//         </select>
+//         {/* 검색바 */}
+//         <input
+//           value={keyword}
+//           onChange={(e) => setKeyword(e.target.value)}
+//           placeholder="찾으시는 글이 있으신가요?"
+//         ></input>
+//         <button onClick={handleSearch}>검색</button>
+//         <button onClick={resetFilter}>초기화</button>
+//       </div>
+//       {/* 정렬 */}
+//       <div className="flex items-center gap-2">
+//         {selectSort.map((option) => (
+//           <label key={option.value}>
+//             <input
+//               type="radio"
+//               key={option.value}
+//               value={option.value}
+//               checked={filters.sortType == option.value}
+//               onChange={() => updateQuery("sortType", option.value)}
+//             />
+//             {option.label}
+//           </label>
+//         ))}
+//         <button onClick={goCreate}>새글쓰기</button>
+//       </div>
+
+//       <ul>
+//         {boards.map((board) => (
+//           <li key={board.id}>
+//             {changeResponse(categories, board.category)}
+//             {changeResponse(petTypes, board.petType)}
+//             {board.title}
+//             {board.content}
+//             {board.nickname}
+//             {board.viewsCount}|{board.likesCount}|{board.commentsCount}
+//             {board.createdAt.split("T")[0]}{" "}
+//           </li>
+//         ))}
+//       </ul>
+//       <Pagination
+//         currentPage={currentPage}
+//         totalPages={totalPages}
+//         blockSize={5}
+//       />
+//     </>
+//   );
+// }
+
 "use client";
 import Pagination from "@/app/components/Pagination";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useState } from "react";
 
-//응답
 interface Board {
   id: number;
   nickname: string;
@@ -239,17 +423,14 @@ export default function BoardListPage({
   const router = useRouter();
   const searchParams = useSearchParams();
   const [keyword, setKeyword] = useState<string>(filters.keyword);
-  //const [loading, setLoading] = useState(false);
+  const [searchType, setSearchType] = useState<string>(filters.searchType);
 
   const updateQuery = (key: string, value: string) => {
-    //setLoading(true);
     const params = new URLSearchParams(searchParams.toString());
     params.set(key, value);
     if (key !== "page") params.set("page", "1");
     router.push(`?${params.toString()}`);
   };
-
-  //if (loading) return <div>로딩 중입니다...</div>;
 
   const categories = [
     { label: "전체", value: "TOTAL" },
@@ -276,8 +457,17 @@ export default function BoardListPage({
     { label: "댓글 순", value: "COMMENTS" },
     { label: "조회 순", value: "VIEWS" },
   ];
+
   function goCreate() {
     router.push("/boards/new");
+  }
+
+  function handleSearch() {
+    const params = new URLSearchParams(searchParams.toString());
+    params.set("searchType", searchType);
+    params.set("keyword", keyword);
+    params.set("page", "1");
+    router.push(`?${params.toString()}`);
   }
 
   function resetFilter() {
@@ -287,6 +477,8 @@ export default function BoardListPage({
     params.set("keyword", "");
     params.set("sortType", "CURRENT");
     params.set("page", "1");
+    setKeyword("");
+    setSearchType("TOTAL");
     router.push(`?${params.toString()}`);
   }
 
@@ -294,27 +486,36 @@ export default function BoardListPage({
     list: T[],
     value: string
   ) {
-    return list.find((item) => item.value == value)?.label;
+    return list.find((item) => item.value === value)?.label;
   }
 
   return (
-    <>
-      {/* 카테고리 바 */}
-      <div className="flex gap-5 p-5">
+    <div className="w-full border-b border-yellow-300 bg-white">
+      {/* 카테고리 탭 */}
+      <div className="max-w-4xl mx-auto flex justify-center gap-40 p-4">
         {categories.map((category) => (
           <button
             key={category.value}
             onClick={() => updateQuery("category", category.value)}
+            className={`text-lg font-semibold transition-colors duration-200 ${
+              filters.category === category.value
+                ? "text-[#F5C044]"
+                : "text-gray-500 hover:text-yellow-400"
+            }`}
           >
             {category.label}
           </button>
         ))}
       </div>
-      {/* 검색 필터링 */}
-      <div className="flex items-center gap-2">
+
+      <hr className="border-t border-gray-400" />
+
+      {/* 검색 필터 영역 */}
+      <div className="flex items-center justify-center gap-6 px-5 py-10 w-full max-w-none">
         <select
-          value={filters.searchType}
-          onChange={(e) => updateQuery("searchType", e.target.value)}
+          value={searchType}
+          onChange={(e) => setSearchType(e.target.value)}
+          className="border border-[#F5C044] rounded-md px-2 py-3 text-sm focus:outline-yellow-400 bg-white"
         >
           {selectOptions.map((op) => (
             <option key={op.value} value={op.value}>
@@ -322,50 +523,121 @@ export default function BoardListPage({
             </option>
           ))}
         </select>
-        {/* 검색바 */}
+
         <input
           value={keyword}
           onChange={(e) => setKeyword(e.target.value)}
           placeholder="찾으시는 글이 있으신가요?"
-        ></input>
-        <button onClick={() => updateQuery("keyword", keyword)}>검색</button>
-        <button onClick={resetFilter}>초기화</button>
+          className="border border-[#F5C044] rounded-md px-4 py-3 text-sm w-full max-w-[700px] focus:outline-yellow-400 bg-white"
+        />
+        <button
+          onClick={handleSearch}
+          className="bg-[#FFF5C4] hover:bg-[#F5C044] text-gray-700 rounded-xl px-3 py-2 text-sm border border-[#F5C044]"
+        >
+          검색
+        </button>
+
+        <button
+          onClick={resetFilter}
+          className="bg-[#FFF5C4] hover:bg-[#F5C044] text-gray-700 rounded-xl px-3 py-2 text-sm border border-[#F5C044]"
+        >
+          초기화
+        </button>
       </div>
+
       {/* 정렬 */}
-      <div className="flex items-center gap-2">
+      <div className="flex items-center gap-4 px-5 py-4 max-w-4xl mx-auto">
         {selectSort.map((option) => (
-          <label key={option.value}>
+          <label
+            key={option.value}
+            className="flex items-center gap-1 text-sm text-gray-700"
+          >
             <input
               type="radio"
-              key={option.value}
               value={option.value}
-              checked={filters.sortType == option.value}
+              checked={filters.sortType === option.value}
               onChange={() => updateQuery("sortType", option.value)}
+              className="accent-yellow-400"
             />
             {option.label}
           </label>
         ))}
-        <button onClick={goCreate}>새글쓰기</button>
+
+        <button
+          onClick={goCreate}
+          className="ml-auto bg-[#F3AD61] hover:bg-[#C57F34] text-black rounded-xl px-5 py-3 text-sm border border-black"
+        >
+          새글쓰기🐾
+        </button>
       </div>
 
-      <ul>
-        {boards.map((board) => (
-          <li key={board.id}>
-            {changeResponse(categories, board.category)}
-            {changeResponse(petTypes, board.petType)}
-            {board.title}
-            {board.content}
-            {board.nickname}
-            {board.viewsCount}|{board.likesCount}|{board.commentsCount}
-            {board.createdAt.split("T")[0]}{" "}
-          </li>
-        ))}
-      </ul>
-      <Pagination
-        currentPage={currentPage}
-        totalPages={totalPages}
-        blockSize={5}
-      />
-    </>
+      <hr className="border-t border-gray-400 mb-6" />
+
+      {/* 게시글 리스트 */}
+      {boards.length === 0 ? (
+        <div className="text-center text-gray-500 py-20 text-lg">
+          검색 결과가 없습니다.
+        </div>
+      ) : (
+        <ul className="px-7 max-w-5xl mx-auto divide-y divide-gray-300">
+          {boards.map((board) => (
+            <li
+              key={board.id}
+              className="flex justify-between items-start py-4"
+            >
+              {/* 본문 */}
+              <div className="flex-1 flex flex-col justify-between pr-4">
+                {/* 라벨 */}
+                <div className="flex gap-4 mb-1">
+                  <span
+                    className="text-xs px-2 py-1 text-yellow-800 rounded-full"
+                    style={{ backgroundColor: "#FFDEA7" }}
+                  >
+                    {changeResponse(categories, board.category)}
+                  </span>
+                  <span
+                    className="text-xs px-2 py-1 text-yellow-800 rounded-full"
+                    style={{ backgroundColor: "#FFF5C4" }}
+                  >
+                    {changeResponse(petTypes, board.petType)}
+                  </span>
+                </div>
+
+                <div className="font-semibold text-base text-gray-800">
+                  {board.title}
+                </div>
+                <div className="text-sm text-gray-500">{board.content}</div>
+                <div className="flex items-center text-xs text-gray-400 mt-2 gap-5">
+                  <span>{board.nickname}</span>
+                  <span>👁 {board.viewsCount}</span>
+                  <span>❤️ {board.likesCount}</span>
+                  <span>💬 {board.commentsCount}</span>
+                  <span>{board.createdAt.split("T")[0]}</span>
+                </div>
+              </div>
+
+              {/* 이미지 */}
+              {board.image_url && (
+                <img
+                  src={board.image_url}
+                  alt="게시물 이미지"
+                  className="w-24 h-24 object-cover rounded-xl"
+                />
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+      <hr className="border-t border-gray-400 my-6" />
+
+      {/* 페이지네이션 */}
+      <div className="mt-4 mb-12 px-5 max-w-4xl mx-auto">
+        <Pagination
+          currentPage={currentPage}
+          totalPages={totalPages}
+          blockSize={5}
+        />
+      </div>
+    </div>
   );
 }

--- a/app/(site)/boards/BoardListClient.tsx
+++ b/app/(site)/boards/BoardListClient.tsx
@@ -509,9 +509,8 @@ export default function BoardListPage({
       </div>
 
       <hr className="border-t border-gray-400" />
-
       {/* 검색 필터 영역 */}
-      <div className="flex items-center justify-center gap-6 px-5 py-10 w-full max-w-none">
+      <div className="flex items-center justify-start gap-6 px-5 py-10 w-full max-w-4xl mx-auto">
         <select
           value={searchType}
           onChange={(e) => setSearchType(e.target.value)}
@@ -532,14 +531,14 @@ export default function BoardListPage({
         />
         <button
           onClick={handleSearch}
-          className="bg-[#FFF5C4] hover:bg-[#F5C044] text-gray-700 rounded-xl px-3 py-2 text-sm border border-[#F5C044]"
+          className="bg-[#FFF5C4] hover:bg-[#F5C044] text-gray-700 rounded-xl px-3 py-2 text-sm border border-[#F5C044] whitespace-nowrap"
         >
           검색
         </button>
 
         <button
           onClick={resetFilter}
-          className="bg-[#FFF5C4] hover:bg-[#F5C044] text-gray-700 rounded-xl px-3 py-2 text-sm border border-[#F5C044]"
+          className="bg-[#FFF5C4] hover:bg-[#F5C044] text-gray-700 rounded-xl px-3 py-2 text-sm border border-[#F5C044] whitespace-nowrap"
         >
           초기화
         </button>
@@ -565,7 +564,7 @@ export default function BoardListPage({
 
         <button
           onClick={goCreate}
-          className="ml-auto bg-[#F3AD61] hover:bg-[#C57F34] text-black rounded-xl px-5 py-3 text-sm border border-black"
+          className="ml-auto bg-[#F3AD61] hover:bg-[#C57F34] text-black rounded-xl px-4 py-3 text-sm border border-black"
         >
           새글쓰기🐾
         </button>

--- a/app/(site)/boards/[id]/page.tsx
+++ b/app/(site)/boards/[id]/page.tsx
@@ -1,7 +1,0 @@
-export default function page() {
-  return (
-    <div>
-      <p>hihih</p>
-    </div>
-  );
-}

--- a/app/(site)/boards/page.tsx
+++ b/app/(site)/boards/page.tsx
@@ -3,11 +3,39 @@
 import api from "@/app/lib/api";
 import { useEffect, useState } from "react";
 
+enum Category {
+  TOTAL = "전체",
+  FREE = "커뮤니티",
+  QNA = "Q & A",
+}
+
+enum petType {
+  DOG = "강아지",
+  CAT = "고양이",
+  ETC = "기타",
+}
+
+interface BoardPage {
+  page: number;
+  size: number;
+  totalPages: number;
+  totalCount: number;
+  boardList: Board[];
+}
+
 interface Board {
   id: number;
   nickname: string;
   title: string;
+  content: string;
+  image_url: string;
+  likesCount: number;
+  viewsCount: number;
+  commentsCount: number;
   createdAt: string;
+  updatedAt: string;
+  category: string;
+  petType: string;
 }
 
 export default function BoardListPage() {
@@ -36,7 +64,13 @@ export default function BoardListPage() {
     <ul>
       {boards.map((board) => (
         <li key={board.id}>
-          {board.nickname}, {board.title} | {board.createdAt}
+          {Category[board.category as keyof typeof Category]}
+          {petType[board.petType as keyof typeof petType]}
+          {board.title}
+          {board.content}
+          {board.nickname}
+          {board.viewsCount}|{board.likesCount}|{board.commentsCount}
+          {board.createdAt.split("T")[0]}{" "}
         </li>
       ))}
     </ul>

--- a/app/(site)/boards/page.tsx
+++ b/app/(site)/boards/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import api from "@/app/lib/api";
-import { get } from "http";
+import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 
 interface BoardPage {
@@ -36,6 +36,8 @@ export default function BoardListPage() {
   const [keyword, setKeyword] = useState<string>("");
   const [search, setSearch] = useState<boolean>(false);
   const [sort, setSort] = useState<string>("CURRENT");
+
+  const router = useRouter();
 
   const categories = [
     { label: "전체", value: "TOTAL" },
@@ -111,6 +113,9 @@ export default function BoardListPage() {
   function checkSort(value: string) {
     setSort(value);
   }
+  function goCreate() {
+    router.push("/boards/new");
+  }
 
   function resetFilter() {
     setOption("TOTAL");
@@ -171,6 +176,7 @@ export default function BoardListPage() {
             {option.label}
           </label>
         ))}
+        <button onClick={goCreate}>새글쓰기</button>
       </div>
 
       <ul>

--- a/app/(site)/boards/page.tsx
+++ b/app/(site)/boards/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import api from "@/app/lib/api";
-import { BADHINTS } from "dns";
 import { useEffect, useState } from "react";
 
 enum Category {
@@ -70,6 +69,16 @@ export default function BoardListPage() {
         <button>커뮤니티</button>
         <button>Q & A</button>
       </div>
+
+      <div className="flex items-center gap-2">
+        <select>
+          <option>전체</option>
+          <option>작성자</option>
+          <option>제목</option>
+          <option>내용</option>
+        </select>
+      </div>
+
       <ul>
         {boards.map((board) => (
           <li key={board.id}>

--- a/app/(site)/boards/page.tsx
+++ b/app/(site)/boards/page.tsx
@@ -1,18 +1,6 @@
-"use client";
+import Pagination from "@/app/components/Pagination";
+import BoardListClient from "./BoardListClient";
 
-import api from "@/app/lib/api";
-import { useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
-
-interface BoardPage {
-  page: number;
-  size: number;
-  totalPages: number;
-  totalCount: number;
-  boardList: Board[];
-}
-
-//응답
 interface Board {
   id: number;
   nickname: string;
@@ -28,170 +16,76 @@ interface Board {
   petType: string;
 }
 
-export default function BoardListPage() {
-  const [boards, setBoards] = useState<Board[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [category, setCategory] = useState<string>("TOTAL");
-  const [option, setOption] = useState<string>("TOTAL");
-  const [keyword, setKeyword] = useState<string>("");
-  const [search, setSearch] = useState<boolean>(false);
-  const [sort, setSort] = useState<string>("CURRENT");
+// 백엔드 응답 구조
+interface BoardPageResponse {
+  boardList: Board[];
+  page: number;
+  size: number;
+  totalPages: number;
+  totalCount: number;
+}
 
-  const router = useRouter();
+interface Filters {
+  category: string;
+  searchType: string;
+  keyword: string;
+  sortType: string;
+  page: string;
+}
 
-  const categories = [
-    { label: "전체", value: "TOTAL" },
-    { label: "커뮤니티", value: "FREE" },
-    { label: "Q & A", value: "QNA" },
-  ];
+// 클라이언트 컴포넌트에 넘겨주는 모든 데이터 타입
+interface Props {
+  boards: Board[];
+  currentPage: number;
+  totalPages: number;
+  filters: Filters;
+}
 
-  const petTypes = [
-    { label: "강아지", value: "DOG" },
-    { label: "고양이", value: "CAT" },
-    { label: "기타", value: "ETC" },
-  ];
+function getQureyParam(
+  searchParams: { [key: string]: string | string[] | undefined },
+  key: string,
+  defaultValue: string
+) {
+  const raw = searchParams[key];
+  const value = Array.isArray(raw) ? raw[0] : raw;
+  return value ?? defaultValue;
+}
 
-  const selectOptions = [
-    { label: "전체", value: "TOTAL" },
-    { label: "작성자", value: "USERNAME" },
-    { label: "제목", value: "TITLE" },
-    { label: "내용", value: "CONTENT" },
-  ];
+export default async function BoardListPage({
+  searchParams,
+}: {
+  searchParams: { [key: string]: string | string[] | undefined };
+}) {
+  const category = getQureyParam(searchParams, "category", "TOTAL");
+  const searchType = getQureyParam(searchParams, "searchType", "TOTAL");
+  const keyword = getQureyParam(searchParams, "keyword", "");
+  const sortType = getQureyParam(searchParams, "sortType", "CURRENT");
+  const pageStr = getQureyParam(searchParams, "page", "1");
+  const page = parseInt(pageStr);
 
-  const selectSort = [
-    { label: "최신 순", value: "CURRENT" },
-    { label: "좋아요 순", value: "LIKES" },
-    { label: "댓글 순", value: "COMMENTS" },
-    { label: "조회 순", value: "VIEWS" },
-  ];
-
-  useEffect(() => {
-    getBoard();
-  }, [category, search, sort]);
-
-  async function getBoard() {
-    // 요청
-    const payload = {
-      category: category,
-      searchType: option,
-      sortType: sort,
-      keyword: keyword,
-      page: 0,
-      size: 10,
-    };
-
-    try {
-      const res = await api.get("/boards", { params: payload });
-      setBoards(res.data.boardList); // 배열만 저장
-      console.log(res.data);
-    } catch (err) {
-      console.error(err);
-    } finally {
-      setLoading(false); // 무조건 로딩 종료
-    }
-  }
-  if (loading) return <h1>Loading…</h1>;
-
-  function selectCategory(value: string) {
-    resetFilter();
-    setCategory(value);
-  }
-
-  function selectOption(e: React.ChangeEvent<HTMLSelectElement>) {
-    setOption(e.target.value);
-  }
-
-  function InputKeyword(e: React.ChangeEvent<HTMLInputElement>) {
-    setKeyword(e.target.value);
-  }
-
-  function searchKeyword(bool: boolean) {
-    setSearch(bool);
-    getBoard();
-  }
-
-  function checkSort(value: string) {
-    setSort(value);
-  }
-  function goCreate() {
-    router.push("/boards/new");
-  }
-
-  function resetFilter() {
-    setOption("TOTAL");
-    setKeyword("");
-    setBoards([]);
-    getBoard();
-  }
-
-  function changeResponse<T extends { label: string; value: string }>(
-    list: T[],
-    value: string
-  ) {
-    return list.find((item) => item.value == value)?.label;
-  }
+  const res = await fetch(
+    `http://localhost:2222/api/v1/boards?category=${category}&searchType=${searchType}&keyword=${keyword}&sortType=${sortType}&page=${
+      page - 1
+    }&size=10`,
+    { cache: "no-store" }
+  );
+  const data: BoardPageResponse = await res.json();
+  const filters: Filters = {
+    category,
+    searchType,
+    keyword,
+    sortType,
+    page: pageStr,
+  };
 
   return (
     <>
-      {/* 카테고리 바 */}
-      <div className="flex gap-5 p-5">
-        {categories.map((category) => (
-          <button
-            key={category.value}
-            onClick={() => selectCategory(category.value)}
-          >
-            {category.label}
-          </button>
-        ))}
-      </div>
-      {/* 검색 필터링 */}
-      <div className="flex items-center gap-2">
-        <select onChange={selectOption} value={option}>
-          {selectOptions.map((op) => (
-            <option key={op.value} value={op.value}>
-              {op.label}
-            </option>
-          ))}
-        </select>
-        {/* 검색바 */}
-        <input
-          value={keyword}
-          onChange={InputKeyword}
-          placeholder="찾으시는 글이 있으신가요?"
-        ></input>
-        <button onClick={() => searchKeyword(true)}>검색</button>
-        <button onClick={resetFilter}>초기화</button>
-      </div>
-      {/* 정렬 */}
-      <div className="flex items-center gap-2">
-        {selectSort.map((option) => (
-          <label key={option.value}>
-            <input
-              type="radio"
-              key={option.value}
-              value={option.value}
-              checked={sort == option.value}
-              onChange={() => checkSort(option.value)}
-            />
-            {option.label}
-          </label>
-        ))}
-        <button onClick={goCreate}>새글쓰기</button>
-      </div>
-
-      <ul>
-        {boards.map((board) => (
-          <li key={board.id}>
-            {changeResponse(categories, board.category)}
-            {changeResponse(petTypes, board.petType)}
-            {board.title}
-            {board.content}
-            {board.nickname}
-            {board.viewsCount}|{board.likesCount}|{board.commentsCount}
-            {board.createdAt.split("T")[0]}{" "}
-          </li>
-        ))}
-      </ul>
+      <BoardListClient
+        boards={data.boardList}
+        currentPage={data.page + 1}
+        totalPages={data.totalPages}
+        filters={filters}
+      />
     </>
   );
 }

--- a/app/(site)/boards/page.tsx
+++ b/app/(site)/boards/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import api from "@/app/lib/api";
+import { BADHINTS } from "dns";
 import { useEffect, useState } from "react";
 
 enum Category {
@@ -61,18 +62,27 @@ export default function BoardListPage() {
   if (loading) return <h1>Loading…</h1>;
 
   return (
-    <ul>
-      {boards.map((board) => (
-        <li key={board.id}>
-          {Category[board.category as keyof typeof Category]}
-          {petType[board.petType as keyof typeof petType]}
-          {board.title}
-          {board.content}
-          {board.nickname}
-          {board.viewsCount}|{board.likesCount}|{board.commentsCount}
-          {board.createdAt.split("T")[0]}{" "}
-        </li>
-      ))}
-    </ul>
+    <>
+      <div>
+        {/* 카테고리 바 */}
+        <div className="flex gap-5 p-5"></div>
+        <button>전체</button>
+        <button>커뮤니티</button>
+        <button>Q & A</button>
+      </div>
+      <ul>
+        {boards.map((board) => (
+          <li key={board.id}>
+            {Category[board.category as keyof typeof Category]}
+            {petType[board.petType as keyof typeof petType]}
+            {board.title}
+            {board.content}
+            {board.nickname}
+            {board.viewsCount}|{board.likesCount}|{board.commentsCount}
+            {board.createdAt.split("T")[0]}{" "}
+          </li>
+        ))}
+      </ul>
+    </>
   );
 }

--- a/app/(site)/boards/page.tsx
+++ b/app/(site)/boards/page.tsx
@@ -35,6 +35,7 @@ export default function BoardListPage() {
   const [option, setOption] = useState<string>("TOTAL");
   const [keyword, setKeyword] = useState<string>("");
   const [search, setSearch] = useState<boolean>(false);
+  const [sort, setSort] = useState<string>("CURRENT");
 
   const categories = [
     { label: "전체", value: "TOTAL" },
@@ -55,16 +56,23 @@ export default function BoardListPage() {
     { label: "내용", value: "CONTENT" },
   ];
 
+  const selectSort = [
+    { label: "최신 순", value: "CURRENT" },
+    { label: "좋아요 순", value: "LIKES" },
+    { label: "댓글 순", value: "COMMENTS" },
+    { label: "조회 순", value: "VIEWS" },
+  ];
+
   useEffect(() => {
     getBoard();
-  }, [category, search]);
+  }, [category, search, sort]);
 
   async function getBoard() {
     // 요청
     const payload = {
       category: category,
       searchType: option,
-      sortType: "CURRENT",
+      sortType: sort,
       keyword: keyword,
       page: 0,
       size: 10,
@@ -98,6 +106,10 @@ export default function BoardListPage() {
   function searchKeyword(bool: boolean) {
     setSearch(bool);
     getBoard();
+  }
+
+  function checkSort(value: string) {
+    setSort(value);
   }
 
   function resetFilter() {
@@ -145,6 +157,22 @@ export default function BoardListPage() {
         <button onClick={() => searchKeyword(true)}>검색</button>
         <button onClick={resetFilter}>초기화</button>
       </div>
+      {/* 정렬 */}
+      <div className="flex items-center gap-2">
+        {selectSort.map((option) => (
+          <label key={option.value}>
+            <input
+              type="radio"
+              key={option.value}
+              value={option.value}
+              checked={sort == option.value}
+              onChange={() => checkSort(option.value)}
+            />
+            {option.label}
+          </label>
+        ))}
+      </div>
+
       <ul>
         {boards.map((board) => (
           <li key={board.id}>

--- a/app/(site)/boards/page.tsx
+++ b/app/(site)/boards/page.tsx
@@ -23,6 +23,7 @@ interface BoardPage {
   boardList: Board[];
 }
 
+//응답
 interface Board {
   id: number;
   nickname: string;
@@ -41,6 +42,9 @@ interface Board {
 export default function BoardListPage() {
   const [boards, setBoards] = useState<Board[]>([]);
   const [loading, setLoading] = useState(true);
+  const [category, setCategory] = useState("전체")
+  const [filter, setFilter] = useState("TOTAL");
+  const [search, setSearch] = useState("")
 
   useEffect(() => {
     getBoard();
@@ -48,7 +52,7 @@ export default function BoardListPage() {
 
   async function getBoard() {
     try {
-      const res = await api.get("/boards");
+      const res = await api.get("/boards", payload);
       setBoards(res.data.boardList); // 배열만 저장
       console.log(res.data);
     } catch (err) {
@@ -57,28 +61,44 @@ export default function BoardListPage() {
       setLoading(false); // 무조건 로딩 종료
     }
   }
+  // 요청
+  const payload = {
+    category: ,
+    searchType: filter,
+    sortType: "CURRENT"
+    keyword: "",
+    page: 0,
+    size: 10
+  };
+
 
   if (loading) return <h1>Loading…</h1>;
 
+  const categories = ["전체", "커뮤니티", "Q & A"];
+
   return (
     <>
-      <div>
         {/* 카테고리 바 */}
-        <div className="flex gap-5 p-5"></div>
-        <button>전체</button>
-        <button>커뮤니티</button>
-        <button>Q & A</button>
+        <div className="flex gap-5 p-5">
+        { categories.map((category) => (
+          <button key={category}
+          onClick = {() => setCategory(category) }>
+            {category}
+          </button>
+        ))}
       </div>
 
       <div className="flex items-center gap-2">
-        <select>
+        <select onChange={searchOption} value={filter}>
           <option>전체</option>
           <option>작성자</option>
           <option>제목</option>
           <option>내용</option>
         </select>
+        <input placeholder="찾으시는 글이 있으신가요?" ></input>
+        <button onClick={}>검색</button>
+        <button>초기화</button>
       </div>
-
       <ul>
         {boards.map((board) => (
           <li key={board.id}>

--- a/app/components/Pagination.tsx
+++ b/app/components/Pagination.tsx
@@ -1,21 +1,104 @@
+// "use client";
+
+// import { useRouter, useSearchParams } from "next/navigation";
+// import { useMemo } from "react";
+
+// interface PagenationProps {
+//   currentPage: number;
+//   totalPages: number;
+//   blockSize: 5; // 한블록 몇 페이지 보여줄지
+// }
+
+// export default function Pagination({
+//   currentPage,
+//   totalPages,
+//   blockSize,
+// }: PagenationProps) {
+//   const router = useRouter();
+//   const searchParams = useSearchParams(); // 쿼리파라미터 가져오기
+
+//   const currentBlock = useMemo(
+//     () => Math.ceil(currentPage / blockSize),
+//     [currentPage, blockSize]
+//   );
+
+//   const startPage = (currentBlock - 1) * blockSize + 1;
+//   const endPage = Math.min(startPage + blockSize - 1, totalPages);
+//   const totalBlocks = Math.ceil(totalPages / blockSize);
+
+//   const createPageUrl = (page: number) => {
+//     const params = new URLSearchParams(searchParams.toString());
+//     params.set("page", page.toString());
+//     return `?${params.toString()}`;
+//   };
+//   const goToPage = (page: number) => {
+//     if (page >= 1 && page <= totalPages && page != currentPage) {
+//       router.push(createPageUrl(page));
+//     }
+//   };
+
+//   const goToBlock = (block: number) => {
+//     const page = (block - 1) * blockSize + 1;
+//     goToPage(page);
+//   };
+
+//   return (
+//     <div>
+//       <button onClick={() => goToBlock(1)} disabled={currentBlock == 1}>
+//         «
+//       </button>
+//       <button
+//         onClick={() => goToBlock(currentBlock - 1)}
+//         disabled={currentBlock == 1}
+//       >
+//         &lt;
+//       </button>
+//       {Array.from({ length: endPage - startPage + 1 }, (_, i) => {
+//         const page = startPage + i;
+//         return (
+//           <button
+//             key={page}
+//             onClick={() => goToPage(page)}
+//             disabled={page == currentPage}
+//           >
+//             {page}
+//           </button>
+//         );
+//       })}
+//       <button
+//         onClick={() => goToBlock(currentBlock + 1)}
+//         disabled={currentBlock == totalBlocks}
+//       >
+//         &gt;
+//       </button>
+//       <button
+//         onClick={() => goToBlock(totalBlocks)}
+//         disabled={currentBlock == totalBlocks}
+//       >
+//         »
+//       </button>
+//     </div>
+//   );
+// }
+
 "use client";
 
 import { useRouter, useSearchParams } from "next/navigation";
 import { useMemo } from "react";
 
-interface PagenationProps {
+interface PaginationProps {
   currentPage: number;
   totalPages: number;
-  blockSize: 5; // 한블록 몇 페이지 보여줄지
+  blockSize: number;
 }
 
 export default function Pagination({
   currentPage,
   totalPages,
   blockSize,
-}: PagenationProps) {
+}: PaginationProps) {
   const router = useRouter();
-  const searchParams = useSearchParams(); // 쿼리파라미터 가져오기
+  const searchParams = useSearchParams();
 
   const currentBlock = useMemo(
     () => Math.ceil(currentPage / blockSize),
@@ -31,8 +114,9 @@ export default function Pagination({
     params.set("page", page.toString());
     return `?${params.toString()}`;
   };
+
   const goToPage = (page: number) => {
-    if (page >= 1 && page <= totalPages && page != currentPage) {
+    if (page >= 1 && page <= totalPages && page !== currentPage) {
       router.push(createPageUrl(page));
     }
   };
@@ -43,37 +127,75 @@ export default function Pagination({
   };
 
   return (
-    <div>
-      <button onClick={() => goToBlock(1)} disabled={currentBlock == 1}>
+    <div className="flex justify-center items-center gap-2 mt-6">
+      {/* 처음 */}
+      <button
+        onClick={() => goToBlock(1)}
+        disabled={currentBlock === 1}
+        className={`px-2 text-sm ${
+          currentBlock === 1
+            ? "text-gray-300 cursor-not-allowed"
+            : "text-yellow-600 hover:text-yellow-800"
+        }`}
+      >
         «
       </button>
+
+      {/* 이전 블록 */}
       <button
         onClick={() => goToBlock(currentBlock - 1)}
-        disabled={currentBlock == 1}
+        disabled={currentBlock === 1}
+        className={`px-2 text-sm ${
+          currentBlock === 1
+            ? "text-gray-300 cursor-not-allowed"
+            : "text-yellow-600 hover:text-yellow-800"
+        }`}
       >
         &lt;
       </button>
+
+      {/* 페이지 번호 */}
       {Array.from({ length: endPage - startPage + 1 }, (_, i) => {
         const page = startPage + i;
+        const isCurrent = page === currentPage;
         return (
           <button
             key={page}
             onClick={() => goToPage(page)}
-            disabled={page == currentPage}
+            disabled={isCurrent}
+            className={`px-3 py-1 text-sm transition ${
+              isCurrent
+                ? "rounded-full bg-yellow-400 text-white cursor-not-allowed"
+                : "text-yellow-700 hover:text-yellow-900"
+            }`}
           >
             {page}
           </button>
         );
       })}
+
+      {/* 다음 블록 */}
       <button
         onClick={() => goToBlock(currentBlock + 1)}
-        disabled={currentBlock == totalBlocks}
+        disabled={currentBlock === totalBlocks}
+        className={`px-2 text-sm ${
+          currentBlock === totalBlocks
+            ? "text-gray-300 cursor-not-allowed"
+            : "text-yellow-600 hover:text-yellow-800"
+        }`}
       >
         &gt;
       </button>
+
+      {/* 마지막 */}
       <button
         onClick={() => goToBlock(totalBlocks)}
-        disabled={currentBlock == totalBlocks}
+        disabled={currentBlock === totalBlocks}
+        className={`px-2 text-sm ${
+          currentBlock === totalBlocks
+            ? "text-gray-300 cursor-not-allowed"
+            : "text-yellow-600 hover:text-yellow-800"
+        }`}
       >
         »
       </button>

--- a/app/components/Pagination.tsx
+++ b/app/components/Pagination.tsx
@@ -23,7 +23,7 @@ export default function Pagination({
   );
 
   const startPage = (currentBlock - 1) * blockSize + 1;
-  const endPage = Math.min(startPage + currentBlock - 1, totalPages);
+  const endPage = Math.min(startPage + blockSize - 1, totalPages);
   const totalBlocks = Math.ceil(totalPages / blockSize);
 
   const createPageUrl = (page: number) => {
@@ -65,16 +65,15 @@ export default function Pagination({
           </button>
         );
       })}
-      ;
       <button
         onClick={() => goToBlock(currentBlock + 1)}
-        disabled={totalBlocks == 1}
+        disabled={currentBlock == totalBlocks}
       >
         &gt;
       </button>
       <button
         onClick={() => goToBlock(totalBlocks)}
-        disabled={totalBlocks == 1}
+        disabled={currentBlock == totalBlocks}
       >
         »
       </button>

--- a/app/components/Pagination.tsx
+++ b/app/components/Pagination.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+import { useMemo } from "react";
+
+interface PagenationProps {
+  currentPage: number;
+  totalPages: number;
+  blockSize: 5; // 한블록 몇 페이지 보여줄지
+}
+
+export default function Pagination({
+  currentPage,
+  totalPages,
+  blockSize,
+}: PagenationProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams(); // 쿼리파라미터 가져오기
+
+  const currentBlock = useMemo(
+    () => Math.ceil(currentPage / blockSize),
+    [currentPage, blockSize]
+  );
+
+  const startPage = (currentBlock - 1) * blockSize + 1;
+  const endPage = Math.min(startPage + currentBlock - 1, totalPages);
+  const totalBlocks = Math.ceil(totalPages / blockSize);
+
+  const createPageUrl = (page: number) => {
+    const params = new URLSearchParams(searchParams.toString());
+    params.set("page", page.toString());
+    return `?${params.toString()}`;
+  };
+  const goToPage = (page: number) => {
+    if (page >= 1 && page <= totalPages && page != currentPage) {
+      router.push(createPageUrl(page));
+    }
+  };
+
+  const goToBlock = (block: number) => {
+    const page = (block - 1) * blockSize + 1;
+    goToPage(page);
+  };
+
+  return (
+    <div>
+      <button onClick={() => goToBlock(1)} disabled={currentBlock == 1}>
+        «
+      </button>
+      <button
+        onClick={() => goToBlock(currentBlock - 1)}
+        disabled={currentBlock == 1}
+      >
+        &lt;
+      </button>
+      {Array.from({ length: endPage - startPage + 1 }, (_, i) => {
+        const page = startPage + i;
+        return (
+          <button
+            key={page}
+            onClick={() => goToPage(page)}
+            disabled={page == currentPage}
+          >
+            {page}
+          </button>
+        );
+      })}
+      ;
+      <button
+        onClick={() => goToBlock(currentBlock + 1)}
+        disabled={totalBlocks == 1}
+      >
+        &gt;
+      </button>
+      <button
+        onClick={() => goToBlock(totalBlocks)}
+        disabled={totalBlocks == 1}
+      >
+        »
+      </button>
+    </div>
+  );
+}

--- a/app/components/Pagination.tsx
+++ b/app/components/Pagination.tsx
@@ -165,7 +165,7 @@ export default function Pagination({
             disabled={isCurrent}
             className={`px-3 py-1 text-sm transition ${
               isCurrent
-                ? "rounded-full bg-yellow-400 text-white cursor-not-allowed"
+                ? "rounded-full bg-[#F5C044]  text-white cursor-not-allowed"
                 : "text-yellow-700 hover:text-yellow-900"
             }`}
           >

--- a/app/components/UserList.tsx
+++ b/app/components/UserList.tsx
@@ -60,7 +60,7 @@ export default function UserList() {
         userSearchType: searchType,
         userSortType: sortType,
         userAscDesc: orderType,
-        keyword, // ← 확정된 키워드
+        keyword, // ← 확정된 키워
       },
     });
     setUsers(res.data.adminUserList);


### PR DESCRIPTION
- 유저가 자유게시판으로 진입 시 게시글 리스트 조회 페이지를 확인할 수 있습니다.
- 네비게이션 바 하단에 카테고리 바에 전체, Q&A, 커뮤니티 항목을 선택할 수 있습니다.
- 검색 버튼 옆에 초기화 버튼으로 검색 결과를 초기화 할 수 있습니다.
- 게시글을 검색 할 수 있으며, 검색 필터링과 정렬 조건을 지정할 수 있습니다.
- ‘새글 쓰기’ 버튼을 클릭 시, 게시글 생성 페이지로 이동합니다.
- 게시글 목록을 확인할 수 있습니다.
- 하단에 페이지네이션을 통해 페이지를 이동할 수 있습니다.