### PR TITLE
feat: 입양 공고 게시글 등록  [#front-19]

### DIFF
--- a/app/(site)/announcements/[id]/page.tsx
+++ b/app/(site)/announcements/[id]/page.tsx
@@ -1,0 +1,98 @@
+import { cookies } from "next/headers";
+
+interface AnnouncementDetailResponse {
+  id: number;
+  breed: string;
+  announcementStatus: string;
+  shelterName: string;
+  createdAt: string;
+  imageUrl: string;
+  gender: string;
+  health: string;
+  personality: string;
+  age: number;
+  announcementPeriod: string;
+}
+
+const baseUrl = process.env.API_BASE_URL ?? "http://localhost:2222/api/v1"; // ✅ 포트 확인도!
+
+async function fetchAnnouncementDetail(
+  id: string
+): Promise<AnnouncementDetailResponse> {
+  const accessToken = cookies().get("accessToken")?.value;
+
+  const res = await fetch(`${baseUrl}/announcements/${id}`, {
+    headers: {
+      Authorization: accessToken ? `Bearer ${accessToken}` : "",
+    },
+    cache: "no-store",
+  });
+
+  if (!res.ok) {
+    throw new Error("Failed to fetch announcement detail");
+  }
+
+  return res.json();
+}
+
+const AnnouncementDetailPage = async ({
+  params,
+}: {
+  params: { id: string };
+}) => {
+  const detail = await fetchAnnouncementDetail(params.id);
+  console.log(detail.imageUrl);
+  console.log(detail.breed);
+
+  return (
+    <main className="max-w-3xl mx-auto py-10 px-4">
+      <h1 className="text-4xl font-extrabold mb-8 text-yellow-600">
+        {detail.breed} 상세정보
+      </h1>
+      {detail.imageUrl ? (
+        <img
+          src={detail.imageUrl}
+          alt={detail.breed}
+          className="w-full max-w-md rounded-xl mb-8 object-cover mx-auto shadow-md"
+        />
+      ) : (
+        <div className="w-full max-w-md h-64 bg-gray-200 rounded-xl mb-8 flex items-center justify-center text-gray-400 mx-auto">
+          이미지 없음
+        </div>
+      )}
+      <section className="space-y-4 text-gray-800 text-lg">
+        <p>
+          <strong>성별:</strong> {detail.gender}
+        </p>
+        <p>
+          <strong>품종:</strong> {detail.breed}
+        </p>
+        <p>
+          <strong>건강 상태:</strong> {detail.health}
+        </p>
+        <p>
+          <strong>성격:</strong> {detail.personality}
+        </p>
+        <p>
+          <strong>나이:</strong> {detail.age}세
+        </p>
+        <p>
+          <strong>보호소:</strong> {detail.shelterName}
+        </p>
+        <p>
+          <strong>등록일:</strong>{" "}
+          {new Date(detail.createdAt).toLocaleDateString()}
+        </p>
+        <p>
+          <strong>공고 기간:</strong>{" "}
+          {new Date(detail.announcementPeriod).toLocaleDateString()}
+        </p>
+        <p>
+          <strong>상태:</strong> {detail.announcementStatus}
+        </p>
+      </section>
+    </main>
+  );
+};
+
+export default AnnouncementDetailPage;

--- a/app/(site)/announcements/create/page.tsx
+++ b/app/(site)/announcements/create/page.tsx
@@ -1,0 +1,123 @@
+// 공고 등록 페이지
+export default function Page() {
+  return (
+    <div className="min-h-screen bg-blue-50 flex flex-col items-center py-10">
+      {/* 상단 네비게이션 */}
+      <nav className="w-full bg-yellow-100 py-3 px-10 flex justify-between items-center text-yellow-600 font-semibold">
+        <span className="text-lg">HELLO PET 🐱</span>
+        <div className="space-x-6">
+          <a href="#">입양게시판</a>
+          <a href="#">자유게시판</a>
+          <a href="#">마이페이지</a>
+          <a href="#">로그아웃</a>
+        </div>
+      </nav>
+
+      {/* 등록 폼 */}
+      <div className="bg-yellow-50 w-full max-w-2xl mt-10 p-10 rounded-xl shadow-md text-yellow-700 font-medium">
+        <h2 className="text-center text-xl mb-8">등록 등록 페이지</h2>
+
+        {/* 동물 종류 */}
+        <div className="mb-4">
+          <label className="block mb-1">동물</label>
+          <div className="space-x-4">
+            <label>
+              <input type="checkbox" className="mr-1" defaultChecked /> 강아지
+            </label>
+            <label>
+              <input type="checkbox" className="mr-1" /> 고양이
+            </label>
+            <label>
+              <input type="checkbox" className="mr-1" /> 기타
+            </label>
+          </div>
+        </div>
+
+        {/* 종류 */}
+        <div className="mb-4">
+          <input
+            type="text"
+            placeholder="종류를 입력해주세요."
+            className="w-full border-b border-yellow-300 bg-transparent outline-none py-2"
+          />
+        </div>
+
+        {/* 성별 */}
+        <div className="mb-4">
+          <label className="block mb-1">성별</label>
+          <div className="flex items-center space-x-6">
+            <label>
+              <input type="radio" name="gender" className="mr-1" /> 남
+            </label>
+            <label>
+              <input type="radio" name="gender" className="mr-1" /> 여
+            </label>
+            <button className="ml-auto flex items-center text-yellow-700 hover:underline">
+              <span className="mr-1">사진첨부하기</span>
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                className="h-4 w-4"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="2"
+                  d="M15 10l4.553-2.276a1 1 0 00-.553-1.894H5a1 1 0 00-.553 1.894L9 10m6 0v6a2 2 0 01-2 2H7a2 2 0 01-2-2v-6m6 0V4"
+                />
+              </svg>
+            </button>
+          </div>
+        </div>
+
+        {/* 상태 입력들 */}
+        <div className="space-y-4">
+          <input
+            type="text"
+            placeholder="건강상태를 입력해주세요."
+            className="w-full border-b border-yellow-300 bg-transparent outline-none py-2"
+          />
+          <input
+            type="text"
+            placeholder="성격을 입력해주세요."
+            className="w-full border-b border-yellow-300 bg-transparent outline-none py-2"
+          />
+          <input
+            type="text"
+            placeholder="나이를 입력해주세요."
+            className="w-full border-b border-yellow-300 bg-transparent outline-none py-2"
+          />
+          <input
+            type="text"
+            placeholder="보호 중인 보호소와 연락처를 입력해주세요."
+            className="w-full border-b border-yellow-300 bg-transparent outline-none py-2"
+          />
+          <input
+            type="text"
+            placeholder="발견장소를 입력해주세요."
+            className="w-full border-b border-yellow-300 bg-transparent outline-none py-2"
+          />
+        </div>
+
+        {/* 공고기간 */}
+        <div className="mt-4 mb-6">
+          <label className="block mb-1">공고기간을 선택해주세요.</label>
+          <input
+            type="date"
+            className="border border-yellow-300 rounded px-2 py-1 bg-white"
+            defaultValue="2025-06-27"
+          />
+        </div>
+
+        {/* 버튼 */}
+        <div className="text-center">
+          <button className="bg-yellow-400 text-white px-6 py-2 rounded-full shadow hover:bg-yellow-500 transition">
+            등록하기
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/(site)/announcements/create/page.tsx
+++ b/app/(site)/announcements/create/page.tsx
@@ -1,119 +1,148 @@
-// 공고 등록 페이지
-export default function Page() {
-  return (
-    <div className="min-h-screen bg-blue-50 flex flex-col items-center py-10">
-      {/* 상단 네비게이션 */}
-      <nav className="w-full bg-yellow-100 py-3 px-10 flex justify-between items-center text-yellow-600 font-semibold">
-        <span className="text-lg">HELLO PET 🐱</span>
-        <div className="space-x-6">
-          <a href="#">입양게시판</a>
-          <a href="#">자유게시판</a>
-          <a href="#">마이페이지</a>
-          <a href="#">로그아웃</a>
-        </div>
-      </nav>
+"use client";
 
-      {/* 등록 폼 */}
+import { useState } from "react";
+import { useRouter } from "next/navigation"; // 여기 추가
+import api from "@/app/lib/api";
+
+export default function Page() {
+  const router = useRouter(); // router 선언
+
+  const [breed, setBreed] = useState("");
+  const [animalType, setAnimalType] = useState("");
+  const [gender, setGender] = useState("");
+  const [healthStatus, setHealthStatus] = useState("");
+  const [personality, setPersonality] = useState("");
+  const [age, setAge] = useState("");
+  const [image, setImage] = useState("");
+  const [selectedDate, setSelectedDate] = useState("");
+
+  const onSubmit = async () => {
+    try {
+      const data = {
+        breed,
+        animalType,
+        gender,
+        health: healthStatus,
+        personality,
+        age: Number(age),
+        image: image || null,
+        selectedDate,
+      };
+
+      console.log("전송 데이터:", data);
+
+      const res = await api.post("/announcements", data);
+      console.log("등록이 되었습니다:", res.data);
+
+      router.push("/announcements"); // router.push 호출 가능!
+
+      alert("등록 성공!");
+    } catch (err) {
+      console.error("등록 실패", err);
+      alert("등록 실패: " + (err instanceof Error ? err.message : "에러 발생"));
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-yellow-30 flex flex-col items-center py-10">
       <div className="bg-yellow-50 w-full max-w-2xl mt-10 p-10 rounded-xl shadow-md text-yellow-700 font-medium">
-        <h2 className="text-center text-xl mb-8">등록 등록 페이지</h2>
+        <h2 className="text-center text-xl mb-8 font-bold">입양 동물 등록</h2>
 
         {/* 동물 종류 */}
         <div className="mb-4">
-          <label className="block mb-1">동물</label>
-          <div className="space-x-4">
-            <label>
-              <input type="checkbox" className="mr-1" defaultChecked /> 강아지
-            </label>
-            <label>
-              <input type="checkbox" className="mr-1" /> 고양이
-            </label>
-            <label>
-              <input type="checkbox" className="mr-1" /> 기타
-            </label>
-          </div>
+          <label className="block mb-1">동물 종류</label>
+          <select
+            className="w-full border-b border-yellow-300 bg-transparent outline-none py-2"
+            value={animalType}
+            onChange={(e) => setAnimalType(e.target.value)}
+          >
+            <option value="">선택하세요</option>
+            <option value="강아지">강아지</option>
+            <option value="고양이">고양이</option>
+            <option value="기타">기타</option>
+          </select>
         </div>
 
-        {/* 종류 */}
+        {/* 견종 */}
         <div className="mb-4">
           <input
             type="text"
-            placeholder="종류를 입력해주세요."
+            placeholder="견종, 묘종을 입력해주세요."
             className="w-full border-b border-yellow-300 bg-transparent outline-none py-2"
+            value={breed}
+            onChange={(e) => setBreed(e.target.value)}
           />
         </div>
 
         {/* 성별 */}
         <div className="mb-4">
           <label className="block mb-1">성별</label>
-          <div className="flex items-center space-x-6">
-            <label>
-              <input type="radio" name="gender" className="mr-1" /> 남
-            </label>
-            <label>
-              <input type="radio" name="gender" className="mr-1" /> 여
-            </label>
-            <button className="ml-auto flex items-center text-yellow-700 hover:underline">
-              <span className="mr-1">사진첨부하기</span>
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                className="h-4 w-4"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth="2"
-                  d="M15 10l4.553-2.276a1 1 0 00-.553-1.894H5a1 1 0 00-.553 1.894L9 10m6 0v6a2 2 0 01-2 2H7a2 2 0 01-2-2v-6m6 0V4"
+          <div className="flex space-x-6">
+            {["남", "여"].map((g) => (
+              <label key={g}>
+                <input
+                  type="radio"
+                  name="gender"
+                  value={g}
+                  checked={gender === g}
+                  onChange={(e) => setGender(e.target.value)}
+                  className="mr-1"
                 />
-              </svg>
-            </button>
+                {g}
+              </label>
+            ))}
           </div>
         </div>
 
-        {/* 상태 입력들 */}
-        <div className="space-y-4">
-          <input
-            type="text"
-            placeholder="건강상태를 입력해주세요."
-            className="w-full border-b border-yellow-300 bg-transparent outline-none py-2"
-          />
-          <input
-            type="text"
-            placeholder="성격을 입력해주세요."
-            className="w-full border-b border-yellow-300 bg-transparent outline-none py-2"
-          />
-          <input
-            type="text"
-            placeholder="나이를 입력해주세요."
-            className="w-full border-b border-yellow-300 bg-transparent outline-none py-2"
-          />
-          <input
-            type="text"
-            placeholder="보호 중인 보호소와 연락처를 입력해주세요."
-            className="w-full border-b border-yellow-300 bg-transparent outline-none py-2"
-          />
-          <input
-            type="text"
-            placeholder="발견장소를 입력해주세요."
-            className="w-full border-b border-yellow-300 bg-transparent outline-none py-2"
-          />
-        </div>
+        {/* 건강 상태, 성격, 나이 */}
+        <input
+          type="text"
+          placeholder="건강상태"
+          value={healthStatus}
+          onChange={(e) => setHealthStatus(e.target.value)}
+          className="w-full mb-2 border-b border-yellow-300 py-2 bg-transparent outline-none"
+        />
+        <input
+          type="text"
+          placeholder="성격"
+          value={personality}
+          onChange={(e) => setPersonality(e.target.value)}
+          className="w-full mb-2 border-b border-yellow-300 py-2 bg-transparent outline-none"
+        />
+        <input
+          type="number"
+          placeholder="나이"
+          value={age}
+          onChange={(e) => setAge(e.target.value)}
+          className="w-full mb-4 border-b border-yellow-300 py-2 bg-transparent outline-none"
+        />
 
-        {/* 공고기간 */}
-        <div className="mt-4 mb-6">
-          <label className="block mb-1">공고기간을 선택해주세요.</label>
+        {/* 공고 종료일 */}
+        <div className="mb-6">
+          <label className="block mb-1">공고 종료일</label>
           <input
-            type="date"
+            type="datetime-local"
+            value={selectedDate}
+            onChange={(e) => setSelectedDate(e.target.value)}
             className="border border-yellow-300 rounded px-2 py-1 bg-white"
-            defaultValue="2025-06-27"
           />
         </div>
 
-        {/* 버튼 */}
+        {/* 이미지 URL */}
+        <input
+          type="text"
+          placeholder="이미지 URL 입력 (선택)"
+          value={image}
+          onChange={(e) => setImage(e.target.value)}
+          className="w-full mb-6 border-b border-yellow-300 py-2 bg-transparent outline-none"
+        />
+
+        {/* 등록 버튼 */}
         <div className="text-center">
-          <button className="bg-yellow-400 text-white px-6 py-2 rounded-full shadow hover:bg-yellow-500 transition">
+          <button
+            className="bg-yellow-400 text-white px-6 py-2 rounded-full shadow hover:bg-yellow-500 transition"
+            onClick={onSubmit}
+          >
             등록하기
           </button>
         </div>

--- a/app/(site)/announcements/edit/[id]/page.tsx
+++ b/app/(site)/announcements/edit/[id]/page.tsx
@@ -1,0 +1,184 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter, useParams } from "next/navigation";
+import api from "@/app/lib/api";
+
+interface AnnouncementForm {
+  breed: string;
+  gender: string;
+  health: string;
+  personality: string;
+  age: number;
+  announcementPeriod: number;
+  image: string;
+}
+
+export default function EditAnnouncementPage() {
+  const params = useParams();
+  const id = params?.id as string;
+  const [form, setForm] = useState<AnnouncementForm>({
+    breed: "",
+    gender: "",
+    health: "",
+    personality: "",
+    age: 0,
+    announcementPeriod: 0,
+    image: "",
+  });
+
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!id) return;
+
+    const fetchDetail = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const res = await api.get(`/announcements/${id}`);
+        const data = res.data;
+
+        setForm({
+          breed: data.breed ?? "",
+          gender: data.gender ?? "",
+          health: data.health ?? "",
+          personality: data.personality ?? "",
+          age: data.age ?? 0,
+          announcementPeriod: data.announcementPeriod ?? 0,
+          image: data.image ?? "",
+        });
+      } catch (err: any) {
+        console.error(
+          "수정 데이터 불러오기 실패",
+          err.response ?? err.message ?? err
+        );
+        setError("데이터를 불러오는 데 실패했습니다.");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchDetail();
+  }, [id]);
+
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
+    const { name, value } = e.target;
+    setForm((prev) => ({
+      ...prev,
+      [name]:
+        name === "age" || name === "announcementPeriod" ? Number(value) : value,
+    }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!id) return;
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const token = localStorage.getItem("accessToken");
+      await api.put(`/announcements/${id}`, form, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
+      alert("수정 완료!");
+      router.push("/me");
+    } catch (err) {
+      console.error("수정 실패", err);
+      setError("수정에 실패했습니다. 다시 시도해주세요.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="max-w-xl mx-auto py-10">
+      <h1 className="text-2xl font-bold mb-6 text-yellow-600">
+        입양 공고 수정
+      </h1>
+
+      {loading && <p className="mb-4 text-center text-gray-500">로딩 중...</p>}
+      {error && (
+        <p className="mb-4 text-center text-red-500 font-semibold">{error}</p>
+      )}
+
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <input
+          name="breed"
+          value={form.breed ?? ""}
+          onChange={handleChange}
+          placeholder="품종"
+          className="border p-2 w-full"
+          disabled={loading}
+        />
+        <input
+          name="gender"
+          value={form.gender ?? ""}
+          onChange={handleChange}
+          placeholder="성별"
+          className="border p-2 w-full"
+          disabled={loading}
+        />
+        <input
+          name="health"
+          value={form.health ?? ""}
+          onChange={handleChange}
+          placeholder="건강 상태"
+          className="border p-2 w-full"
+          disabled={loading}
+        />
+        <input
+          name="personality"
+          value={form.personality ?? ""}
+          onChange={handleChange}
+          placeholder="성격"
+          className="border p-2 w-full"
+          disabled={loading}
+        />
+        <input
+          type="number"
+          name="age"
+          value={form.age}
+          onChange={handleChange}
+          placeholder="나이"
+          className="border p-2 w-full"
+          disabled={loading}
+        />
+        <input
+          type="number"
+          name="announcementPeriod"
+          value={form.announcementPeriod}
+          onChange={handleChange}
+          placeholder="공고 기간(일)"
+          className="border p-2 w-full"
+          disabled={loading}
+        />
+        <input
+          name="image"
+          value={form.image ?? ""}
+          onChange={handleChange}
+          placeholder="이미지 URL"
+          className="border p-2 w-full"
+          disabled={loading}
+        />
+
+        <button
+          type="submit"
+          disabled={loading}
+          className="w-full py-2 bg-yellow-500 text-white rounded hover:bg-yellow-600 disabled:bg-yellow-300"
+        >
+          수정 완료
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/app/(site)/announcements/page.tsx
+++ b/app/(site)/announcements/page.tsx
@@ -2,48 +2,124 @@
 
 import api from "@/app/lib/api";
 import { useEffect, useState } from "react";
+import Link from "next/link";
 
 interface Announcement {
-    id: number;
-    status: string;
-    image: string;
-    breed: string;
+  id: number;
+  breed: string;
+  status: string;
+  shelterName: string;
+  createdAt: string;
+  image: string | null;
 }
 
+const ITEMS_PER_PAGE = 9;
+
 export default function AnnouncementsPage() {
-    const [announcements, setAnnouncements] = useState<Announcement[]>([]);
-    const [loading, setLoading] = useState(true);
+  const [announcements, setAnnouncements] = useState<Announcement[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [page, setPage] = useState(0);
 
-    useEffect(() => {
-        getAnnouncement();
-    }, []);
+  const totalPages = Math.ceil(announcements.length / ITEMS_PER_PAGE);
 
-    async function getAnnouncement() {
-        try {
-            const res = await api.get("/announcements");
-            setAnnouncements(res.data.announcements);
-            console.log(res.data);
-        } catch (err) {
-            console.error(err);
-        } finally {
-            setLoading(false); // 무조건 로딩 종료
-        }
+  useEffect(() => {
+    fetchAnnouncements();
+  }, []);
+
+  async function fetchAnnouncements() {
+    try {
+      const res = await api.get("/announcements");
+      setAnnouncements(res.data.announcements ?? []);
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setLoading(false);
     }
+  }
 
-    if (loading) return <h1>Loading…</h1>;
+  const currentPageItems = announcements.slice(
+    page * ITEMS_PER_PAGE,
+    (page + 1) * ITEMS_PER_PAGE
+  );
 
-    return (
-        <ul className="grid grid-cols-4 gap-4">
-            {announcements.map((announcement) => (
-                <li
-                    key={announcement.id}
-                    className="flex flex-col items-center space-y-1 rounded-lg border p-2 shadow-sm"
-                >
-                    <img src={announcement.image} />
-                    <p className="text-sm font-medium">breed: {announcement.breed}</p>
-                    <p className="text-xs text-gray-600">status: {announcement.status}</p>
-                </li>
-            ))}
-        </ul>
-    );
+  const goPrev = () => {
+    if (page > 0) setPage(page - 1);
+  };
+
+  const goNext = () => {
+    if (page < totalPages - 1) setPage(page + 1);
+  };
+
+  if (loading) return <h1 className="text-center mt-20 text-xl">Loading…</h1>;
+
+  return (
+    <div className="min-h-screen bg-white py-10 px-4">
+      <h1 className="text-center text-yellow-500 font-semibold text-lg mb-6">
+        입양게시판
+      </h1>
+
+      <ul className="grid grid-cols-3 gap-6 max-w-5xl mx-auto mb-6">
+        {currentPageItems.map((item) => (
+          <li key={item.id}>
+            <Link
+              href={`/announcements/${item.id}`}
+              className="block flex flex-col items-center bg-white shadow-md rounded-xl p-4 cursor-pointer hover:bg-gray-50 transition"
+            >
+              {item.image ? (
+                <img
+                  src={item.image}
+                  alt={item.breed}
+                  className="w-36 h-36 object-cover rounded-xl mb-2"
+                />
+              ) : (
+                <div className="w-36 h-36 bg-gray-200 rounded-xl mb-2 flex items-center justify-center text-gray-400">
+                  이미지 없음
+                </div>
+              )}
+              <p className="text-xs text-gray-700 font-semibold">
+                {item.breed}
+              </p>
+              <p className="text-xs text-gray-500">
+                상태: {item.status} / 보호소: {item.shelterName}
+              </p>
+              <p className="text-xs text-gray-400">
+                등록일: {new Date(item.createdAt).toLocaleDateString()}
+              </p>
+            </Link>
+          </li>
+        ))}
+      </ul>
+
+      {/* 화살표 페이지네이션 */}
+      <div className="flex justify-center items-center space-x-4">
+        <button
+          onClick={goPrev}
+          disabled={page === 0}
+          className={`px-3 py-1 rounded ${
+            page === 0
+              ? "bg-gray-300 text-white cursor-not-allowed"
+              : "bg-yellow-400 text-white hover:bg-yellow-500"
+          }`}
+        >
+          ◀
+        </button>
+
+        <span className="text-sm text-gray-600">
+          {page + 1} / {totalPages}
+        </span>
+
+        <button
+          onClick={goNext}
+          disabled={page >= totalPages - 1}
+          className={`px-3 py-1 rounded ${
+            page >= totalPages - 1
+              ? "bg-gray-300 text-white cursor-not-allowed"
+              : "bg-yellow-400 text-white hover:bg-yellow-500"
+          }`}
+        >
+          ▶
+        </button>
+      </div>
+    </div>
+  );
 }

--- a/app/(site)/me/page.tsx
+++ b/app/(site)/me/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import ApplicationList from "@/app/components/ApplicationList";
+import MyAnnouncementsPage from "@/app/components/MyAnnouncements";
 import RequireRole from "@/app/components/RequireRole";
 import UserDetail from "@/app/components/UserDetail";
 import UserList from "@/app/components/UserList";
@@ -9,124 +10,125 @@ import Head from "next/head";
 import { useState } from "react";
 
 export default function MyPage() {
-    const user = useUserStore((s) => s.user);
+  const user = useUserStore((s) => s.user);
 
-    const [myPage, setMyPage] = useState(true);
-    const [roleChangedBtn, setRoleChangedBtn] = useState(false);
-    const [myBoard, setMyBoard] = useState(false);
-    const [myComment, setMyComment] = useState(false);
+  const [myPage, setMyPage] = useState(true);
+  const [roleChangedBtn, setRoleChangedBtn] = useState(false);
+  const [myBoard, setMyBoard] = useState(false);
+  const [myComment, setMyComment] = useState(false);
 
-    /* ---------------- 탭 전환 ---------------- */
-    const toggle = (tab: "page" | "role" | "board" | "comment") => {
-        setMyPage(tab === "page");
-        setRoleChangedBtn(tab === "role");
-        setMyBoard(tab === "board");
-        setMyComment(tab === "comment");
-    };
+  /* ---------------- 탭 전환 ---------------- */
+  const toggle = (tab: "page" | "role" | "board" | "comment") => {
+    setMyPage(tab === "page");
+    setRoleChangedBtn(tab === "role");
+    setMyBoard(tab === "board");
+    setMyComment(tab === "comment");
+  };
 
-    return (
-        <RequireRole allow={["USER", "ADMIN", "SHELTER"]} fallback="/auth/login">
-            <div className="flex flex-col items-center bg-gray-50 pt-[5vh] min-h-screen">
-                {/* --- 프로필 --- */}
-                <img
-                    src={user?.profileUrl}
-                    alt="Profile"
-                    className="h-32 w-32 rounded-full object-cover shadow"
-                />
-                <div className="mt-6 text-center">
-                    <p className="text-xl font-semibold text-gray-800">{user?.nickname}</p>
-                    <p className="mt-1 text-sm text-gray-500">{user?.email}</p>
-                </div>
+  return (
+    <RequireRole allow={["USER", "ADMIN", "SHELTER"]} fallback="/auth/login">
+      <div className="flex flex-col items-center bg-gray-50 pt-[5vh] min-h-screen">
+        {/* --- 프로필 --- */}
+        <img
+          src={user?.profileUrl}
+          alt="Profile"
+          className="h-32 w-32 rounded-full object-cover shadow"
+        />
+        <div className="mt-6 text-center">
+          <p className="text-xl font-semibold text-gray-800">
+            {user?.nickname}
+          </p>
+          <p className="mt-1 text-sm text-gray-500">{user?.email}</p>
+        </div>
 
+        {/* --- 본문 영역 --- */}
+        <div className="mt-12 flex w-full max-w-[960px] items-start gap-2 px-2">
+          {/* 사이드 메뉴 */}
+          <nav className="flex flex-col space-y-5">
+            <button
+              onClick={() => toggle("page")}
+              className={`w-40 rounded-lg py-2 font-semibold shadow-sm transition ${
+                myPage
+                  ? "bg-amber-400 text-white"
+                  : "bg-amber-50 text-amber-300 hover:bg-amber-100"
+              }`}
+            >
+              개인정보수정
+            </button>
+            {user?.role === "ADMIN" ? (
+              <button
+                onClick={() => toggle("role")}
+                className={`w-40 rounded-lg py-2 font-semibold shadow-sm transition ${
+                  roleChangedBtn
+                    ? "bg-amber-400 text-white"
+                    : "bg-amber-50 text-amber-300 hover:bg-amber-100"
+                }`}
+              >
+                유저목록
+              </button>
+            ) : user?.role === "SHELTER" ? (
+              <button
+                onClick={() => toggle("role")}
+                className={`w-40 rounded-lg py-2 font-semibold shadow-sm transition ${
+                  roleChangedBtn
+                    ? "bg-amber-400 text-white"
+                    : "bg-amber-50 text-amber-300 hover:bg-amber-100"
+                }`}
+              >
+                공고내역
+              </button>
+            ) : (
+              <button
+                onClick={() => toggle("role")}
+                className={`w-40 rounded-lg py-2 font-semibold shadow-sm transition ${
+                  roleChangedBtn
+                    ? "bg-amber-400 text-white"
+                    : "bg-amber-50 text-amber-300 hover:bg-amber-100"
+                }`}
+              >
+                입양신청내역
+              </button>
+            )}
+            <button
+              onClick={() => toggle("board")}
+              className={`w-40 rounded-lg py-2 font-semibold shadow-sm transition ${
+                myBoard
+                  ? "bg-amber-400 text-white"
+                  : "bg-amber-50 text-amber-300 hover:bg-amber-100"
+              }`}
+            >
+              내가 쓴 게시글
+            </button>
+            <button
+              onClick={() => toggle("comment")}
+              className={`w-40 rounded-lg py-2 font-semibold shadow-sm transition ${
+                myComment
+                  ? "bg-amber-400 text-white"
+                  : "bg-amber-50 text-amber-300 hover:bg-amber-100"
+              }`}
+            >
+              내가 쓴 댓글
+            </button>
+          </nav>
 
-                {/* --- 본문 영역 --- */}
-                <div className="mt-12 flex w-full max-w-[960px] items-start gap-2 px-2">
-                    {/* 사이드 메뉴 */}
-                    <nav className="flex flex-col space-y-5">
-                        <button
-                            onClick={() => toggle("page")}
-                            className={`w-40 rounded-lg py-2 font-semibold shadow-sm transition ${
-                                myPage
-                                    ? "bg-amber-400 text-white"
-                                    : "bg-amber-50 text-amber-300 hover:bg-amber-100"
-                            }`}
-                        >
-                            개인정보수정
-                        </button>
-                        {user?.role === "ADMIN" ? (
-                            <button
-                                onClick={() => toggle("role")}
-                                className={`w-40 rounded-lg py-2 font-semibold shadow-sm transition ${
-                                    roleChangedBtn
-                                        ? "bg-amber-400 text-white"
-                                        : "bg-amber-50 text-amber-300 hover:bg-amber-100"
-                                }`}
-                            >
-                                유저목록
-                            </button>
-                        ) : user?.role === "SHELTER" ? (
-                            <button
-                                onClick={() => toggle("role")}
-                                className={`w-40 rounded-lg py-2 font-semibold shadow-sm transition ${
-                                    roleChangedBtn
-                                        ? "bg-amber-400 text-white"
-                                        : "bg-amber-50 text-amber-300 hover:bg-amber-100"
-                                }`}
-                            >
-                                공고내역
-                            </button>
-                        ) : (
-                            <button
-                                onClick={() => toggle("role")}
-                                className={`w-40 rounded-lg py-2 font-semibold shadow-sm transition ${
-                                    roleChangedBtn
-                                        ? "bg-amber-400 text-white"
-                                        : "bg-amber-50 text-amber-300 hover:bg-amber-100"
-                                }`}
-                            >
-                                입양신청내역
-                            </button>
-                        )}
-                        <button
-                            onClick={() => toggle("board")}
-                            className={`w-40 rounded-lg py-2 font-semibold shadow-sm transition ${
-                                myBoard
-                                    ? "bg-amber-400 text-white"
-                                    : "bg-amber-50 text-amber-300 hover:bg-amber-100"
-                            }`}
-                        >
-                            내가 쓴 게시글
-                        </button>
-                        <button
-                            onClick={() => toggle("comment")}
-                            className={`w-40 rounded-lg py-2 font-semibold shadow-sm transition ${
-                                myComment
-                                    ? "bg-amber-400 text-white"
-                                    : "bg-amber-50 text-amber-300 hover:bg-amber-100"
-                            }`}
-                        >
-                            내가 쓴 댓글
-                        </button>
-                    </nav>
-
-                    {/* 컨텐츠 패널 */}
-                    <div className="flex-1 overflow-x-auto">
-                        <div className="flex-none min-w-[720px] rounded-2xl border border-gray-300 bg-white p-8 shadow-md space-y-8">
-                            {myPage && <UserDetail />}
-                            {roleChangedBtn &&
-                                (user?.role === "ADMIN" ? (
-                                    <UserList />
-                                ) : user?.role === "SHELTER" ? (
-                                    <div className="text-center py-10">shelter</div>
-                                ) : (
-                                    <ApplicationList />
-                                ))}
-                            {myBoard && <h1 className="text-center py-10">myBoard</h1>}
-                            {myComment && <h1 className="text-center py-10">myComment</h1>}
-                        </div>
-                    </div>
-                </div>
+          {/* 컨텐츠 패널 */}
+          <div className="flex-1 overflow-x-auto">
+            <div className="flex-none min-w-[720px] rounded-2xl border border-gray-300 bg-white p-8 shadow-md space-y-8">
+              {myPage && <UserDetail />}
+              {roleChangedBtn &&
+                (user?.role === "ADMIN" ? (
+                  <UserList />
+                ) : user?.role === "SHELTER" ? (
+                  <MyAnnouncementsPage />
+                ) : (
+                  <ApplicationList />
+                ))}
+              {myBoard && <h1 className="text-center py-10">myBoard</h1>}
+              {myComment && <h1 className="text-center py-10">myComment</h1>}
             </div>
-        </RequireRole>
-    );
+          </div>
+        </div>
+      </div>
+    </RequireRole>
+  );
 }

--- a/app/components/MyAnnouncements.tsx
+++ b/app/components/MyAnnouncements.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import api from "@/app/lib/api";
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+
+interface AnnouncementListItem {
+  id: number;
+  breed: string;
+  status: string;
+  shelterName: string;
+  createdAt: string;
+  image: string | null;
+}
+
+interface AnnouncementPageResponse {
+  page: number;
+  size: number;
+  totalPages: number;
+  totalCount: number;
+  announcements: AnnouncementListItem[];
+}
+
+export default function MyAnnouncementsPage() {
+  const [myAnnouncements, setMyAnnouncements] = useState<
+    AnnouncementListItem[]
+  >([]);
+  const [loading, setLoading] = useState(true);
+  const router = useRouter();
+
+  useEffect(() => {
+    fetchMyAnnouncements();
+  }, []);
+
+  async function fetchMyAnnouncements() {
+    try {
+      const token = localStorage.getItem("accessToken");
+      const res = await api.get<AnnouncementPageResponse>("/me/announcements", {
+        headers: { Authorization: token ? `Bearer ${token}` : "" },
+      });
+      setMyAnnouncements(res.data.announcements ?? []);
+    } catch (err) {
+      console.error("공고 불러오기 실패", err);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleDelete(id: number) {
+    const confirmed = confirm("정말 삭제하시겠습니까?");
+    if (!confirmed) return;
+
+    try {
+      const token = localStorage.getItem("accessToken");
+      await api.delete(`/announcements/${id}`, {
+        headers: { Authorization: token ? `Bearer ${token}` : "" },
+      });
+      alert("삭제 완료!");
+      fetchMyAnnouncements(); // 삭제 후 다시 목록 로드
+    } catch (err) {
+      console.error("삭제 실패", err);
+      alert("삭제 실패");
+    }
+  }
+
+  if (loading) return <p className="text-center mt-20 text-lg">불러오는 중…</p>;
+
+  return (
+    <div className="min-h-screen bg-white py-10 px-4">
+      <h1 className="text-center text-yellow-500 text-2xl font-bold mb-8">
+        내가 등록한 입양 공고
+      </h1>
+
+      <ul className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6 max-w-5xl mx-auto">
+        {myAnnouncements.map((item) => (
+          <li key={item.id} className="bg-yellow-50 p-4 rounded-xl shadow">
+            <Link
+              href={`/announcements/${item.id}`}
+              className="block hover:bg-yellow-100 transition rounded-xl"
+            >
+              {item.image ? (
+                <img
+                  src={item.image}
+                  alt={item.breed}
+                  className="w-full h-48 object-cover rounded-lg mb-3"
+                />
+              ) : (
+                <div className="w-full h-48 bg-gray-200 flex items-center justify-center rounded-lg text-gray-400 mb-3">
+                  이미지 없음
+                </div>
+              )}
+              <p className="text-yellow-700 font-semibold">{item.breed}</p>
+              <p className="text-sm text-gray-600">상태: {item.status}</p>
+              <p className="text-sm text-gray-600">
+                보호소: {item.shelterName}
+              </p>
+              <p className="text-sm text-gray-500">
+                등록일: {new Date(item.createdAt).toLocaleDateString()}
+              </p>
+            </Link>
+
+            {/* 버튼 영역 */}
+            <div className="mt-4 flex justify-between gap-2">
+              <button
+                onClick={() => router.push(`/announcements/edit/${item.id}`)}
+                className="px-3 py-1 text-sm bg-blue-500 text-white rounded hover:bg-blue-600"
+              >
+                수정
+              </button>
+              <button
+                onClick={() => handleDelete(item.id)}
+                className="px-3 py-1 text-sm bg-red-500 text-white rounded hover:bg-red-600"
+              >
+                삭제
+              </button>
+              <button
+                onClick={() => router.push(`/applications/${item.id}`)}
+                className="px-3 py-1 text-sm bg-gray-600 text-white rounded hover:bg-gray-700"
+              >
+                신청내역
+              </button>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -5,6 +5,14 @@
   --foreground: #171717;
 }
 
+@font-face {
+  font-family: "GowunDodum-Regular";
+  src: url("https://fastly.jsdelivr.net/gh/projectnoonnu/noonfonts_2108@1.1/GowunDodum-Regular.woff")
+    format("woff");
+  font-weight: normal;
+  font-style: normal;
+}
+
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
@@ -22,5 +30,4 @@
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
 }

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -11,6 +11,10 @@ const api = axios.create({
   timeout: 5000,
 });
 
+export const serverApi = axios.create({
+  baseURL: process.env.NEXT_PUBLIC_BASE_URL,
+});
+
 let isRefreshing = false;
 let queue: {
   resolve: (value: AxiosResponse) => void;

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -11,10 +11,6 @@ const api = axios.create({
   timeout: 5000,
 });
 
-export const serverApi = axios.create({
-  baseURL: process.env.NEXT_PUBLIC_BASE_URL,
-});
-
 let isRefreshing = false;
 let queue: {
   resolve: (value: AxiosResponse) => void;


### PR DESCRIPTION
[입양 게시글 등록  [#front-19]]
- 유저가 게시글 리스트 페이지에서 게시글 생성 버튼을 클릭 시, 생성페이지로 이동합니다.
- 생성페이지에서는 입양 상세정보, 동물 종류, 제목, 내용 , 사진 첨부 할 수 있습니다.
- 등록하기 버튼을 클릭하면, 서버로 데이터를 전송합니다.
- 전송 성공 시, 게시글 디테일 페이지로 이동합니다.
- 전송 실패 시, 에러 메세지 알람을 보여줍니다.

[입양 공고 리스트 조회 [#front-28]]
- /announcements 엔드포인트로 전체 리스트를 조회합니다.
- 입양 공고 전체 리스트에는 공고 id, 이미지, 공고 상태 등이 보입니다.
- item 클릭을 하면 상세 정보로 넘어갑니다.

[입양 공고 상세 조회 [#front-29]]
- /announcemets/{id}  엔드포인트로 상세 정보를 조회합니다.
- 상세 정보에는 이미지, 견종, 보호소, 입양 상태, 성격, 건강 상태 등이 조회됩니다.

[내가 작성한 공고 내역 조회 [#front-30]]
- /me 엔드포인트로 내가 작성한 입양 공고 내역이 조회됩니다.
- 입양 공고 내역에서는 수정, 삭제, 신청내역 작업을 진행 할 수 있습니다.

[내가 작성한 입양 공고 수정  [#front-31]]
- 내가 작성한 입양 공고를 수정할 수 있습니다.
- 수정 버튼을 누르면 /me 페이지로 넘어갑니다.