### PR TITLE
신청 내역 및 신청서 UI/UX 개선 및 권한 처리 [#front-38]

### DIFF
--- a/app/(site)/announcements/[id]/applications/page.tsx
+++ b/app/(site)/announcements/[id]/applications/page.tsx
@@ -1,16 +1,27 @@
 "use client";
 
 import AnnouncementApplicationList from "@/app/components/announcementApplications/AnnouncementApplicationList";
-import { useParams } from "next/navigation";
-import { useState, useEffect } from "react";
+import { useParams, useRouter } from "next/navigation";
 
 export default function AnnouncementApplicationsPage() {
     const { id } = useParams<{ id: string }>();
+    const router = useRouter();
 
     return (
         <div className="max-w-4xl mx-auto p-6 space-y-6">
-            <h1 className="text-2xl font-bold text-center mb-15">공고별 신청 내역</h1>
+            <h1 className="text-2xl font-bold text-center mb-4">공고별 신청 내역</h1>
+
             <AnnouncementApplicationList announcementId={Number(id)} />
+
+            {/* 이전 페이지로 돌아가기 버튼 */}
+            <div className="text-right">
+                <button
+                    onClick={() => router.back()}
+                    className="text-sm text-gray-600 border border-gray-300 px-3 py-1 rounded hover:bg-gray-100 transition"
+                >
+                    뒤로 가기
+                </button>
+            </div>
         </div>
     );
 }

--- a/app/components/announcementApplications/AnnouncementApplicationItem.tsx
+++ b/app/components/announcementApplications/AnnouncementApplicationItem.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/navigation";
 interface Props {
     application: {
         applicationId: number;
+        applicationStatusLabel: string;
         userName: string;
         userPhoneNumber: string;
         userEmail: string;
@@ -18,23 +19,31 @@ export default function AnnouncementApplicationItem({ application, onApprove }: 
 
     return (
         <div className="flex justify-between items-center border-b border-gray-300 py-2">
-            <div className="flex-1 flex space-x-20 text-base">
+            <div className="flex-1 flex space-x-6 text-base items-center">
+                {/* 상태 뱃지 */}
+                <span className="px-3 py-0.5 text-sm rounded-xl bg-gray-200 text-gray-700 font-semibold">
+                    {application.applicationStatusLabel}
+                </span>
+
+                {/* 사용자 정보 */}
                 <span className="w-24">{application.userName}</span>
                 <span className="w-32">{formatPhoneNumber(application.userPhoneNumber)}</span>
                 <span className="w-48">{application.userEmail}</span>
             </div>
+
+            {/* 버튼 영역 */}
             <div className="flex space-x-3">
                 <button
                     onClick={() => router.push(`/applications/${application.applicationId}`)}
                     className="bg-amber-400 text-white text-sm px-3 py-1 rounded-xl hover:bg-amber-500"
                 >
-                    신청서
+                    신청서 보기
                 </button>
                 <button
                     onClick={onApprove}
                     className="bg-amber-100 text-amber-800 text-sm px-3 py-1 rounded-xl hover:bg-amber-200"
                 >
-                    승인
+                    승인하기
                 </button>
             </div>
         </div>

--- a/app/components/announcementApplications/AnnouncementApplicationList.tsx
+++ b/app/components/announcementApplications/AnnouncementApplicationList.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useSearchParams } from "next/navigation";
 import api from "@/app/lib/api";
 import AnnouncementApplicationItem from "./AnnouncementApplicationItem";
 import ConfirmModal from "@/app/components/ConfirmModal";
@@ -13,6 +13,7 @@ interface Props {
 
 interface Application {
     applicationId: number;
+    applicationStatusLabel: string;
     userName: string;
     userPhoneNumber: string;
     userEmail: string;
@@ -25,12 +26,7 @@ export default function AnnouncementApplicationList({ announcementId }: Props) {
     const [selectedAppId, setSelectedAppId] = useState<number | null>(null);
 
     const searchParams = useSearchParams();
-    const router = useRouter();
     const currentPage = Number(searchParams.get("page")) || 1;
-
-    useEffect(() => {
-        fetchApplications(currentPage);
-    }, [currentPage]);
 
     const fetchApplications = async (pageNum: number) => {
         try {
@@ -45,12 +41,16 @@ export default function AnnouncementApplicationList({ announcementId }: Props) {
         }
     };
 
+    useEffect(() => {
+        fetchApplications(currentPage);
+    }, [currentPage]);
+
     const handleApprove = async () => {
         if (selectedAppId === null) return;
         try {
             await api.put(`/announcements/${announcementId}/applications/${selectedAppId}`);
             alert("신청이 승인되었습니다.");
-            router.push(`/`);
+            await fetchApplications(currentPage);
         } catch (e: any) {
             alert("승인에 실패했습니다: " + (e.response?.data?.message || e.message));
         } finally {

--- a/app/components/announcementApplications/AnnouncementApplicationList.tsx
+++ b/app/components/announcementApplications/AnnouncementApplicationList.tsx
@@ -50,7 +50,7 @@ export default function AnnouncementApplicationList({ announcementId }: Props) {
         try {
             await api.put(`/announcements/${announcementId}/applications/${selectedAppId}`);
             alert("신청이 승인되었습니다.");
-            await fetchApplications(currentPage);
+            await fetchApplications(currentPage); // 상태 갱신
         } catch (e: any) {
             alert("승인에 실패했습니다: " + (e.response?.data?.message || e.message));
         } finally {
@@ -71,14 +71,20 @@ export default function AnnouncementApplicationList({ announcementId }: Props) {
                 </span>
             </div>
 
-            {/* 신청자 리스트 */}
-            {applications.map((app) => (
-                <AnnouncementApplicationItem
-                    key={app.applicationId}
-                    application={app}
-                    onApprove={() => setSelectedAppId(app.applicationId)}
-                />
-            ))}
+            {/* 신청자 리스트 또는 없음 안내 */}
+            {applications.length === 0 ? (
+                <div className="text-center text-gray-500 py-10">
+                    해당 공고에 접수된 신청 내역이 없습니다.
+                </div>
+            ) : (
+                applications.map((app) => (
+                    <AnnouncementApplicationItem
+                        key={app.applicationId}
+                        application={app}
+                        onApprove={() => setSelectedAppId(app.applicationId)}
+                    />
+                ))
+            )}
 
             {/* 페이지네이션 */}
             {totalPages > 1 && (

--- a/app/components/application/ApplicationItem.tsx
+++ b/app/components/application/ApplicationItem.tsx
@@ -2,19 +2,12 @@ interface Props {
     application: {
         applicationId: number;
         announcementId: number;
-        applicationStatusLabel: string;
+        applicationStatusLabel: string; // 이제는 이미 한글 상태로 전달됨
         submittedAt: string;
         petImageUrl: string;
     };
     onClick: () => void;
 }
-
-const STATUS_LABEL_MAP: Record<string, string> = {
-    APPROVED: "승인",
-    PENDING: "대기",
-    REJECTED: "거절",
-    CANCELLED: "취소",
-};
 
 export default function ApplicationItem({ application, onClick }: Props) {
     return (
@@ -26,8 +19,7 @@ export default function ApplicationItem({ application, onClick }: Props) {
                             입양
                         </span>
                         <span className="bg-amber-400 text-white text-base px-3 py-1 rounded-xl">
-                            {STATUS_LABEL_MAP[application.applicationStatusLabel] ||
-                                application.applicationStatusLabel}
+                            {application.applicationStatusLabel}
                         </span>
                     </div>
                     <div className="flex space-x-15">

--- a/app/components/application/form/ApplicationForm.tsx
+++ b/app/components/application/form/ApplicationForm.tsx
@@ -22,6 +22,7 @@ import CareSection from "./section/CareSection";
 import FinancialSection from "./section/FinancialSection";
 import PetExperienceSection from "./section/PetExperienceSection";
 import FuturePlanSection from "./section/FuturePlanSection";
+import RequireRole from "../../RequireRole";
 
 export default function ApplicationForm() {
     const router = useRouter();
@@ -78,38 +79,43 @@ export default function ApplicationForm() {
     };
 
     return (
-        <div className="max-w-2xl mx-auto p-6 bg-[#FFFDF0] shadow rounded-xl space-y-6 my-10">
-            <h1 className="text-xl font-bold text-center mb-8">입양 신청서</h1>
+        <RequireRole allow={["USER"]} fallback="/auth/login">
+            <div className="max-w-2xl mx-auto p-6 bg-[#FFFDF0] shadow rounded-xl space-y-6 my-10">
+                <h1 className="text-xl font-bold text-center mb-8">입양 신청서</h1>
 
-            <ApplicationInfoSection
-                reason={reason}
-                setReason={setReason}
-                name={userDetail?.nickname || user?.nickname || "-"}
-                phoneNumber={userDetail?.phoneNumber || "-"}
-                email={user?.email || "-"}
-            />
+                <ApplicationInfoSection
+                    reason={reason}
+                    setReason={setReason}
+                    name={userDetail?.nickname || user?.nickname || "-"}
+                    phoneNumber={userDetail?.phoneNumber || "-"}
+                    email={user?.email || "-"}
+                />
 
-            <HousingSection housingInfo={housingInfo} setHousingInfo={setHousingInfo} />
-            <FamilySection familyInfo={familyInfo} setFamilyInfo={setFamilyInfo} />
-            <CareSection careInfo={careInfo} setCareInfo={setCareInfo} />
-            <FinancialSection financialInfo={financialInfo} setFinancialInfo={setFinancialInfo} />
-            <PetExperienceSection
-                petExperienceInfo={petExperienceInfo}
-                setPetExperienceInfo={setPetExperienceInfo}
-            />
-            <FuturePlanSection
-                futurePlanInfo={futurePlanInfo}
-                setFuturePlanInfo={setFuturePlanInfo}
-            />
+                <HousingSection housingInfo={housingInfo} setHousingInfo={setHousingInfo} />
+                <FamilySection familyInfo={familyInfo} setFamilyInfo={setFamilyInfo} />
+                <CareSection careInfo={careInfo} setCareInfo={setCareInfo} />
+                <FinancialSection
+                    financialInfo={financialInfo}
+                    setFinancialInfo={setFinancialInfo}
+                />
+                <PetExperienceSection
+                    petExperienceInfo={petExperienceInfo}
+                    setPetExperienceInfo={setPetExperienceInfo}
+                />
+                <FuturePlanSection
+                    futurePlanInfo={futurePlanInfo}
+                    setFuturePlanInfo={setFuturePlanInfo}
+                />
 
-            <AgreementSection agreement={agreement} setAgreement={setAgreement} />
+                <AgreementSection agreement={agreement} setAgreement={setAgreement} />
 
-            <button
-                onClick={handleSubmit}
-                className="bg-amber-400 text-white font-semibold py-1 px-5 rounded-xl hover:bg-amber-500 mx-auto block mt-20"
-            >
-                입양 신청
-            </button>
-        </div>
+                <button
+                    onClick={handleSubmit}
+                    className="bg-amber-400 text-white font-semibold py-1 px-5 rounded-xl hover:bg-amber-500 mx-auto block mt-20"
+                >
+                    입양 신청
+                </button>
+            </div>
+        </RequireRole>
     );
 }

--- a/app/components/application/form/section/FamilySection.tsx
+++ b/app/components/application/form/section/FamilySection.tsx
@@ -53,7 +53,7 @@ export default function FamilySection({ familyInfo, setFamilyInfo, isReadOnly = 
                     {/* 가족 수 */}
                     <div className="space-y-3">
                         <p className="font-medium text-sm">
-                            현재 함께 거주하는 가족은 몇 명인가요?
+                            현재 함께 거주하는 가족은 본인을 포함하여 몇 명인가요?
                         </p>
                         <input
                             type="number"


### PR DESCRIPTION
- 일반 사용자가 아니면 신청서를 생성할 수 없음
- 입양 신청서 문항이 명확하여 사용자 혼란 없음
- 공고별 신청 내역에서 각 신청서의 처리 상태를 한눈에 확인 가능
- 신청 내역이 없을 경우 안내 메시지와 함께 뒤로가기 버튼 제공하여 UX 향상