### PR TITLE
승인된 입양 신청서 삭제 차단 기능 추가 [#front-39]

### DIFF
--- a/app/components/application/ApplicationList.tsx
+++ b/app/components/application/ApplicationList.tsx
@@ -58,7 +58,13 @@ export default function ApplicationList() {
                     <ApplicationItem
                         key={app.applicationId}
                         application={app}
-                        onClick={() => setSelectedId(app.applicationId)}
+                        onClick={() => {
+                            if (app.applicationStatusLabel === "승인") {
+                                alert("승인된 신청서는 삭제할 수 없습니다.");
+                                return;
+                            }
+                            setSelectedId(app.applicationId);
+                        }}
                     />
                 ))
             )}


### PR DESCRIPTION
- 입양 신청서 상태가 '승인'인 경우 삭제 모달이 뜨지 않아야 함
- 승인된 신청서를 클릭하면 "삭제할 수 없습니다" 안내 메시지 표시