### PR TITLE
공고 접근 권한 없을 경우 사용자 안내 및 메인페이지 이동 처리 [#front-40]

### DIFF
--- a/app/components/announcementApplications/AnnouncementApplicationList.tsx
+++ b/app/components/announcementApplications/AnnouncementApplicationList.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { useSearchParams } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import api from "@/app/lib/api";
 import AnnouncementApplicationItem from "./AnnouncementApplicationItem";
 import ConfirmModal from "@/app/components/ConfirmModal";
@@ -27,6 +27,7 @@ export default function AnnouncementApplicationList({ announcementId }: Props) {
 
     const searchParams = useSearchParams();
     const currentPage = Number(searchParams.get("page")) || 1;
+    const router = useRouter();
 
     const fetchApplications = async (pageNum: number) => {
         try {
@@ -36,8 +37,13 @@ export default function AnnouncementApplicationList({ announcementId }: Props) {
             setApplications(res.data.applications);
             setTotalPages(res.data.totalPages);
             setAnnouncementCreatedAt(res.data.announcementCreatedAt);
-        } catch {
-            alert("신청 내역을 불러오지 못했습니다.");
+        } catch (e: any) {
+            if (e.response?.status === 403) {
+                alert("해당 공고에 대한 접근 권한이 없습니다.");
+                router.push("/");
+            } else {
+                alert("신청 내역을 불러오지 못했습니다.");
+            }
         }
     };
 
@@ -50,7 +56,7 @@ export default function AnnouncementApplicationList({ announcementId }: Props) {
         try {
             await api.put(`/announcements/${announcementId}/applications/${selectedAppId}`);
             alert("신청이 승인되었습니다.");
-            await fetchApplications(currentPage); // 상태 갱신
+            await fetchApplications(currentPage);
         } catch (e: any) {
             alert("승인에 실패했습니다: " + (e.response?.data?.message || e.message));
         } finally {


### PR DESCRIPTION
- 로그인한 보호소가 본인이 등록하지 않은 공고에 접근할 경우 백엔드에서 403 Forbidden 응답을 받음
- 프론트는 해당 응답을 감지하고, 사용자에게 명확한 안내 메시지를 보여줌
- 안내 후 메인페이지 또는 적절한 페이지로 리디렉션됨